### PR TITLE
Added sorting for Appstream table

### DIFF
--- a/src/Components/LifecycleChart/LifecycleChart.tsx
+++ b/src/Components/LifecycleChart/LifecycleChart.tsx
@@ -32,7 +32,6 @@ const LifecycleChart: React.FC<LifecycleChartProps> = ({ lifecycleData }: Lifecy
     }
     if (dataType === 'appLifecycle') {
       lifecycleData.forEach((item: any) => {
-        console.log(item);
         if (item.start_date === 'Unknown' || item.end_date === 'Unknown' || item.rhel_major_version === 8) {
           return;
         }

--- a/src/Components/LifecycleTable/LifecycleTable.tsx
+++ b/src/Components/LifecycleTable/LifecycleTable.tsx
@@ -32,15 +32,23 @@ export const LifecycleTable: React.FunctionComponent<LifecycleTableProps> = ({ d
   // Index of the currently sorted column
   // Note: if you intend to make columns reorderable, you may instead want to use a non-numeric key
   // as the identifier of the sorted column. See the "Compound expandable" example.
-  const [activeSortIndex, setActiveSortIndex] = React.useState<number | undefined>(undefined);
-  // Sort direction of the currently sorted column
-  const [activeSortDirection, setActiveSortDirection] = React.useState<'asc' | 'desc' | undefined>(undefined);
+  const [activeSystemSortIndex, setActiveSystemSortIndex] = React.useState<number | undefined>(undefined);
+  const [activeAppSortIndex, setActiveAppSortIndex] = React.useState<number | undefined>(undefined);
+
+  // Sort direction of the currently sorted column 
+  const [activeSystemSortDirection, setActiveSystemSortDirection] = React.useState<'asc' | 'desc' | undefined>(undefined);
+  const [activeAppSortDirection, setActiveAppSortDirection] = React.useState<'asc' | 'desc' | undefined>(undefined);
+
   const [page, setPage] = React.useState(1);
   const [perPage, setPerPage] = React.useState(10);
   const [paginatedRows, setPaginatedRows] = React.useState(data.slice(0, 10));
 
   React.useEffect(() => {
     setPaginatedRows(data.slice(0, perPage));
+    setActiveAppSortDirection(undefined);
+    setActiveSystemSortDirection(undefined);
+    setActiveAppSortIndex(undefined);
+    setActiveSystemSortIndex(undefined);
   }, [data]);
 
   const handleSetPage = (
@@ -102,15 +110,28 @@ export const LifecycleTable: React.FunctionComponent<LifecycleTableProps> = ({ d
     return [name, rhel_major_version, start_date, end_date, systems];
   };
 
-  const getSortParams = (columnIndex: number): ThProps['sort'] => ({
+  const getSystemSortParams = (columnIndex: number): ThProps['sort'] => ({
     sortBy: {
-      index: activeSortIndex,
-      direction: activeSortDirection,
+      index: activeSystemSortIndex,
+      direction: activeSystemSortDirection,
       defaultDirection: 'asc', // starting sort direction when first sorting a column. Defaults to 'asc'
     },
     onSort: (_event, index, direction) => {
-      setActiveSortIndex(index);
-      setActiveSortDirection(direction);
+      setActiveSystemSortIndex(index);
+      setActiveSystemSortDirection(direction);
+    },
+    columnIndex,
+  });
+
+  const getAppSortParams = (columnIndex: number): ThProps['sort'] => ({
+    sortBy: {
+      index: activeAppSortIndex,
+      direction: activeAppSortDirection,
+      defaultDirection: 'asc', // starting sort direction when first sorting a column. Defaults to 'asc'
+    },
+    onSort: (_event, index, direction) => {
+      setActiveAppSortIndex(index);
+      setActiveAppSortDirection(direction);
     },
     columnIndex,
   });
@@ -127,19 +148,19 @@ export const LifecycleTable: React.FunctionComponent<LifecycleTableProps> = ({ d
     // We shouldn't store the list of data in state because we don't want to have to sync that with props.
     let sortedRepositories = data as Stream[];
 
-    if (typeof activeSortIndex !== 'undefined') {
+    if (typeof activeAppSortIndex !== 'undefined') {
       sortedRepositories = sortedRepositories.sort((a: Stream, b: Stream) => {
-        const aValue = getAppSortableRowValues(a)[activeSortIndex];
-        const bValue = getAppSortableRowValues(b)[activeSortIndex];
+        const aValue = getAppSortableRowValues(a)[activeAppSortIndex];
+        const bValue = getAppSortableRowValues(b)[activeAppSortIndex];
         if (typeof aValue === 'number') {
           // Numeric sort
-          if (activeSortDirection === 'asc') {
+          if (activeAppSortDirection === 'asc') {
             return (aValue as number) - (bValue as number);
           }
           return (bValue as number) - (aValue as number);
         } else {
           // String sort
-          if (activeSortDirection === 'asc') {
+          if (activeAppSortDirection === 'asc') {
             return (aValue as string).localeCompare(bValue as string);
           }
           return (bValue as string).localeCompare(aValue as string);
@@ -164,27 +185,26 @@ export const LifecycleTable: React.FunctionComponent<LifecycleTableProps> = ({ d
         </Tr>
       );
     });
-    
   };
 
   const renderSystemLifecycleData = (data: SystemLifecycleChanges[]) => {
     // Note that we perform the sort as part of the component's render logic and not in onSort.
     // We shouldn't store the list of data in state because we don't want to have to sync that with props.
     let sortedRepositories = data as SystemLifecycleChanges[];
-
-    if (typeof activeSortIndex !== 'undefined') {
+    if (typeof activeSystemSortIndex !== 'undefined') {
       sortedRepositories = sortedRepositories.sort((a: SystemLifecycleChanges, b: SystemLifecycleChanges) => {
-        const aValue = getSystemSortableRowValues(a)[activeSortIndex];
-        const bValue = getSystemSortableRowValues(b)[activeSortIndex];
+        const aValue = getSystemSortableRowValues(a)[activeSystemSortIndex];
+        const bValue = getSystemSortableRowValues(b)[activeSystemSortIndex];
         if (typeof aValue === 'number') {
           // Numeric sort
-          if (activeSortDirection === 'asc') {
+          if (activeSystemSortDirection === 'asc') {
             return (aValue as number) - (bValue as number);
           }
           return (bValue as number) - (aValue as number);
         } else {
           // String sort
-          if (activeSortDirection === 'asc') {
+
+          if (activeSystemSortDirection === 'asc') {
             return (aValue as string).localeCompare(bValue as string);
           }
           return (bValue as string).localeCompare(aValue as string);
@@ -217,17 +237,17 @@ export const LifecycleTable: React.FunctionComponent<LifecycleTableProps> = ({ d
       case 'streams':
         return (
           <Tr key={LIFECYCLE_COLUMN_NAMES.name}>
-            <Th sort={getSortParams(0)}>{LIFECYCLE_COLUMN_NAMES.name}</Th>
-            <Th modifier="wrap" sort={getSortParams(1)}>
+            <Th sort={getAppSortParams(0)}>{LIFECYCLE_COLUMN_NAMES.name}</Th>
+            <Th modifier="wrap" sort={getAppSortParams(1)}>
               {LIFECYCLE_COLUMN_NAMES.release}
             </Th>
-            <Th modifier="wrap" sort={getSortParams(2)}>
+            <Th modifier="wrap" sort={getAppSortParams(2)}>
               {LIFECYCLE_COLUMN_NAMES.release_date}
             </Th>
-            <Th modifier="wrap" sort={getSortParams(3)}>
+            <Th modifier="wrap" sort={getAppSortParams(3)}>
               {LIFECYCLE_COLUMN_NAMES.retirement_date}
             </Th>
-            <Th >
+            <Th>
               {LIFECYCLE_COLUMN_NAMES.systems}
             </Th>
           </Tr>
@@ -235,17 +255,17 @@ export const LifecycleTable: React.FunctionComponent<LifecycleTableProps> = ({ d
       case 'rhel':
         return (
           <Tr key={LIFECYCLE_COLUMN_NAMES.name}>
-            <Th sort={getSortParams(0)}>{LIFECYCLE_COLUMN_NAMES.name}</Th>
-            <Th modifier="wrap" sort={getSortParams(1)}>
+            <Th sort={getSystemSortParams(0)}>{LIFECYCLE_COLUMN_NAMES.name}</Th>
+            <Th modifier="wrap" sort={getSystemSortParams(1)}>
               {LIFECYCLE_COLUMN_NAMES.release}
             </Th>
-            <Th modifier="wrap" sort={getSortParams(2)}>
+            <Th modifier="wrap" sort={getSystemSortParams(2)}>
               {LIFECYCLE_COLUMN_NAMES.release_date}
             </Th>
-            <Th modifier="wrap" sort={getSortParams(3)}>
+            <Th modifier="wrap" sort={getSystemSortParams(3)}>
               {LIFECYCLE_COLUMN_NAMES.retirement_date}
             </Th>
-            <Th modifier="wrap" sort={getSortParams(4)}>
+            <Th modifier="wrap" sort={getSystemSortParams(4)}>
               {LIFECYCLE_COLUMN_NAMES.systems}
             </Th>
           </Tr>

--- a/src/Components/LifecycleTable/LifecycleTable.tsx
+++ b/src/Components/LifecycleTable/LifecycleTable.tsx
@@ -158,8 +158,8 @@ export const LifecycleTable: React.FunctionComponent<LifecycleTableProps> = ({ d
             {repo.name}
           </Td>
           <Td dataLabel={APP_LIFECYCLE_COLUMN_NAMES.release}>{repo.rhel_major_version}</Td>
-          <Td dataLabel={APP_LIFECYCLE_COLUMN_NAMES.release_date}>{Moment(repo.start_date).format('MMM YYYY')}</Td>
-          <Td dataLabel={APP_LIFECYCLE_COLUMN_NAMES.retirement_date}>{Moment(repo.end_date).format('MMM YYYY')}</Td>
+          <Td dataLabel={APP_LIFECYCLE_COLUMN_NAMES.release_date}>{formatDate(repo.start_date)}</Td>
+          <Td dataLabel={APP_LIFECYCLE_COLUMN_NAMES.retirement_date}>{formatDate(repo.end_date)}</Td>
           <Td dataLabel={APP_LIFECYCLE_COLUMN_NAMES.systems}>N/A</Td>
         </Tr>
       );

--- a/src/types/Stream.ts
+++ b/src/types/Stream.ts
@@ -11,4 +11,5 @@ export interface Stream {
   stream: string;
   version: string;
   rhel_major_version: number; // we are adding this on FE side from AppLifecycleChanges type
+  systems: number; // placeholder for when system counts get added to the data
 }


### PR DESCRIPTION
### Description
<!-- Must include 2-3 sentence summary of proposed changes -->
<!-- Must include links to impacted UI(s) or information regarding the impacted UI -->
<!-- Must include any relevant steps to reproduce (if not clear in tracked issue or story) -->
<!-- Must include RSPEED-XXX link (if proposed change involves tracked issue or story) -->
This PR adds the ability for Lifecycle appstreams in the table to be sorted. Sorting for the systems column has been disabled until we get that data inside the api.
Jira link:
[RSPEED-XXX](https://issues.redhat.com/browse/RSPEED-XXX)

---

### Screenshots
<!-- Before and after proposed changes is ideal -->
<!-- Any key UI permutations should be captured -->
<!-- Draw attention to the area of UI that has changed -->
#### Before:


#### After:

![image](https://github.com/user-attachments/assets/5d1c5fdb-c90a-4f62-b6f4-0b674c3891a0)

---

### Checklist ☑️
- [x] PR only fixes one issue or story <!-- open new PR for others -->
- [ ] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [ ] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [ ] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [ ] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##
