### PR TITLE
Clean up lifecycle and upcoming work to better match design

### DIFF
--- a/src/Components/LifecycleChart/LifecycleChart.tsx
+++ b/src/Components/LifecycleChart/LifecycleChart.tsx
@@ -223,10 +223,10 @@ const LifecycleChart: React.FC<LifecycleChartProps> = ({ lifecycleData }: Lifecy
         legendPosition="bottom-left"
         name="chart5"
         padding={{
-          bottom: 100, // Adjusted to accommodate legend
+          bottom: 60, // Adjusted to accommodate legend
           left: 160,
           right: 50, // Adjusted to accommodate tooltip
-          top: 50,
+          top: 20,
         }}
         // adjust this by number of items
         height={updatedLifecycleData.length * 15 + 300}

--- a/src/Components/LifecycleTable/LifecycleTable.tsx
+++ b/src/Components/LifecycleTable/LifecycleTable.tsx
@@ -102,7 +102,7 @@ export const LifecycleTable: React.FunctionComponent<LifecycleTableProps> = ({ d
   const toolbar = (
     <Toolbar>
       <ToolbarContent>
-        <ToolbarItem variant="pagination">{buildPagination('top', false)}</ToolbarItem>
+        <ToolbarItem variant="pagination">{buildPagination('top', true)}</ToolbarItem>
       </ToolbarContent>
     </Toolbar>
   );
@@ -311,11 +311,11 @@ export const LifecycleTable: React.FunctionComponent<LifecycleTableProps> = ({ d
   return (
     <>
       {toolbar}
-      <Table aria-label={getAriaLabel()}>
+      <Table aria-label={getAriaLabel()} variant="compact">
         <Thead>{renderHeaders()}</Thead>
         <Tbody>{renderData()}</Tbody>
       </Table>
-      {buildPagination('bottom', true)}
+      {buildPagination('bottom', false)}
     </>
   );
 };

--- a/src/Components/UpcomingTable/UpcomingTable.tsx
+++ b/src/Components/UpcomingTable/UpcomingTable.tsx
@@ -182,9 +182,11 @@ export const UpcomingTable: React.FunctionComponent<UpcomingTableProps> = ({ dat
       <Table aria-label="Upcoming changes, deprecations, and additions to your system" variant="compact">
         <Thead>
           <Tr>
-            <Th>
-              <span className="pf-v5-u-screen-reader">Row expansion</span>
-            </Th>
+            {filteredData.length > 0 && (
+              <Th>
+                <span className="pf-v5-u-screen-reader">Row expansion</span>
+              </Th>
+            )}
             <Th width={10}>{columnNames.name}</Th>
             <Th width={10}>{columnNames.type}</Th>
             <Th width={10}>{columnNames.release}</Th>

--- a/src/Components/UpcomingTable/UpcomingTableFilters.tsx
+++ b/src/Components/UpcomingTable/UpcomingTableFilters.tsx
@@ -538,12 +538,6 @@ export const UpcomingTableFilters: React.FunctionComponent<UpcomingTableFiltersP
             </ToolbarFilter>
           </ToolbarGroup>
         </ToolbarToggleGroup>
-        <ToolbarItem>
-          <ToggleGroup>
-            <ToggleGroupItem text="Relevant Only" buttonId="toggle1" />
-            <ToggleGroupItem text="All" buttonId="toggle2" />
-          </ToggleGroup>
-        </ToolbarItem>
         <ToolbarItem variant="pagination">{buildPagination('top', true)}</ToolbarItem>
       </ToolbarContent>
     </Toolbar>


### PR DESCRIPTION
### Description
Clean up lifecycle and upcoming pages.
* Swapped lifecycle pagination positions
* Lifecycle table is compact 
* Lifecycle chart spacing is tighter
* Dropped unused upcoming filter
* Dropped unused header in filtered upcoming

Jira link:
[RSPEED-XXX](https://issues.redhat.com/browse/RSPEED-XXX)

---

### Screenshots
<!-- Before and after proposed changes is ideal -->
<!-- Any key UI permutations should be captured -->
<!-- Draw attention to the area of UI that has changed -->
#### Before:
<img width="1172" alt="Screenshot 2025-02-28 at 1 13 42 PM" src="https://github.com/user-attachments/assets/bfa69424-8de1-41a5-ad81-962c10bcbbf2" />
<img width="1173" alt="Screenshot 2025-02-28 at 1 13 51 PM" src="https://github.com/user-attachments/assets/b77e54e7-f05c-419d-999e-0e741f4150e7" />


#### After:

<img width="1165" alt="Screenshot 2025-02-28 at 1 13 04 PM" src="https://github.com/user-attachments/assets/bf52dc43-cbd1-47a5-ae78-b82fd35434bc" />
<img width="1171" alt="Screenshot 2025-02-28 at 1 12 20 PM" src="https://github.com/user-attachments/assets/4d6d8022-ad1c-4a93-bcb3-e591a202ab5c" />

---

### Checklist ☑️
- [ ] PR only fixes one issue or story <!-- open new PR for others -->
- [ ] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [ ] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [ ] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [ ] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##
