### PR TITLE
feat(UpcomingTable): Add expand all/close all arrow

### DIFF
--- a/src/Components/UpcomingRow/UpcomingRow.tsx
+++ b/src/Components/UpcomingRow/UpcomingRow.tsx
@@ -3,7 +3,7 @@ import { Record, columnNames } from '../Upcoming/mock_data';
 import ExclamationCircleIcon from '@patternfly/react-icons/dist/esm/icons/exclamation-circle-icon';
 import ExclamationTriangleIcon from '@patternfly/react-icons/dist/esm/icons/exclamation-triangle-icon';
 import InfoCircleIcon from '@patternfly/react-icons/dist/esm/icons/info-circle-icon';
-import React, { useState } from 'react';
+import React from 'react';
 import { Tbody, Td, Tr } from '@patternfly/react-table';
 import {
   Icon,
@@ -20,12 +20,29 @@ interface TableRowProps {
   repo: Record;
   columnNames: typeof columnNames;
   rowIndex: number;
+  isExpanded: boolean;
+  hideRepo: () => void;
+  showRepo: () => void;
 }
 
-export const TableRow: React.FunctionComponent<TableRowProps> = ({ repo, rowIndex, columnNames }) => {
-  const [isRepoExpanded, setIsRepoExpanded] = useState(false);
+export const TableRow: React.FunctionComponent<TableRowProps> = ({
+  repo,
+  rowIndex,
+  columnNames,
+  isExpanded,
+  showRepo,
+  hideRepo,
+}) => {
   let childIsFullWidth = false;
   let childHasNoPadding = false;
+
+  const onToggle = () => {
+    if (isExpanded) {
+      hideRepo();
+    } else {
+      showRepo();
+    }
+  };
 
   // Set Icons for the type column
   let typeIcon = null;
@@ -56,14 +73,15 @@ export const TableRow: React.FunctionComponent<TableRowProps> = ({ repo, rowInde
     childIsFullWidth = [1, 3].includes(detailFormat);
     childHasNoPadding = [2, 3].includes(detailFormat);
   }
+
   return (
-    <Tbody isExpanded={isRepoExpanded}>
+    <Tbody isExpanded={isExpanded}>
       <Tr>
         <Td
           expand={{
             rowIndex: rowIndex,
-            isExpanded: isRepoExpanded,
-            onToggle: () => setIsRepoExpanded(!isRepoExpanded),
+            isExpanded,
+            onToggle,
             expandId: 'composable-expandable-example',
           }}
         />
@@ -84,7 +102,7 @@ export const TableRow: React.FunctionComponent<TableRowProps> = ({ repo, rowInde
         </Td>
       </Tr>
       {repo.details ? (
-        <Tr isExpanded={isRepoExpanded}>
+        <Tr isExpanded={isExpanded}>
           {!childIsFullWidth ? <Td /> : null}
           <Td className="drf-lifecycle__upcoming-row" dataLabel="Summary" noPadding={childHasNoPadding} colSpan={3}>
             <div className="drf-lifecycle__upcoming-row-text-container">

--- a/src/Components/UpcomingTable/UpcomingTable.tsx
+++ b/src/Components/UpcomingTable/UpcomingTable.tsx
@@ -14,6 +14,7 @@ import {
 import { SortByDirection, Table, Tbody, Td, Th, ThProps, Thead, Tr } from '@patternfly/react-table';
 import { TableRow } from '../../Components/UpcomingRow/UpcomingRow';
 import SearchIcon from '@patternfly/react-icons/dist/esm/icons/search-icon';
+import AngleDownIcon from '@patternfly/react-icons/dist/esm/icons/angle-down-icon';
 import './upcoming-table.scss';
 import { UpcomingChanges } from '../../types/UpcomingChanges';
 import UpcomingTableFilters from './UpcomingTableFilters';
@@ -55,6 +56,7 @@ export const UpcomingTable: React.FunctionComponent<UpcomingTableProps> = ({
   const [activeSortIndex, setActiveSortIndex] = React.useState<number>();
   const [activeSortDirection, setActiveSortDirection] = React.useState<SortByDirection>();
   const [sortedFilteredData, setSortedFilteredData] = React.useState<UpcomingChanges[]>(data);
+  const [expandedRows, setExpandedRows] = React.useState<Set<UpcomingChanges>>(new Set([]));
 
   useEffect(() => {
     if (initialFilters.size === 0) {
@@ -235,6 +237,26 @@ export const UpcomingTable: React.FunctionComponent<UpcomingTableProps> = ({
     type: type,
   }));
 
+  const onClickArrow = () => {
+    if (expandedRows.size < paginatedRows.length) {
+      setExpandedRows(new Set(paginatedRows));
+    } else {
+      setExpandedRows(new Set([]));
+    }
+  };
+
+  const removeRepo = (repo: UpcomingChanges) => {
+    const newExpandedRows = new Set([...expandedRows]);
+    newExpandedRows.delete(repo);
+    setExpandedRows(newExpandedRows);
+  };
+
+  const addRepo = (repo: UpcomingChanges) => {
+    const newExpandedRows = new Set([...expandedRows]);
+    newExpandedRows.add(repo);
+    setExpandedRows(newExpandedRows);
+  };
+
   return (
     <React.Fragment>
       <UpcomingTableFilters
@@ -262,7 +284,19 @@ export const UpcomingTable: React.FunctionComponent<UpcomingTableProps> = ({
           <Tr>
             {filteredData.length > 0 && (
               <Th>
-                <span className="pf-v5-u-screen-reader">Row expansion</span>
+                <span className="pf-v5-c-table__td pf-v5-c-table__toggle">
+                  <Button
+                    aria-expanded={expandedRows.size === paginatedRows.length}
+                    aria-label={expandedRows.size === paginatedRows.length ? 'Collapse all rows' : 'Expand all rows'}
+                    variant="plain"
+                    onClick={onClickArrow}
+                    className={expandedRows.size === paginatedRows.length ? 'pf-m-expanded' : ''}
+                  >
+                    <div className="pf-v5-c-table__toggle-icon">
+                      <AngleDownIcon />
+                    </div>
+                  </Button>
+                </span>
               </Th>
             )}
             <Th width={10} sort={getSortParams(0)}>
@@ -295,6 +329,9 @@ export const UpcomingTable: React.FunctionComponent<UpcomingTableProps> = ({
                 repo={repo}
                 columnNames={columnNames}
                 rowIndex={rowIndex}
+                isExpanded={expandedRows.has(repo)}
+                hideRepo={() => removeRepo(repo)}
+                showRepo={() => addRepo(repo)}
               />
             );
           })


### PR DESCRIPTION
### Description
Add arrow that can control and react to state of expandable panels.

Jira link:
[RSPEED-XXX](https://issues.redhat.com/browse/RSPEED-XXX)

---

### Screenshots
<!-- Before and after proposed changes is ideal -->
<!-- Any key UI permutations should be captured -->
<!-- Draw attention to the area of UI that has changed -->
#### Before:


#### After:


---

### Checklist ☑️
- [ ] PR only fixes one issue or story <!-- open new PR for others -->
- [ ] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [ ] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [ ] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [ ] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##
