### PR TITLE
Update tasks resources and rename pipeline

### DIFF
--- a/.tekton/pull-request.yaml
+++ b/.tekton/pull-request.yaml
@@ -46,15 +46,19 @@ spec:
 
   taskRunSpecs:
     - pipelineTaskName: sast-coverity-check
-      stepOverrides:
+      stepSpecs:
         - name: build
           computeResources:
             requests:
+              memory: 8Gi
+            limits:
               memory: 8Gi
 
         - name: postprocess
           computeResources:
             requests:
+              memory: 8Gi
+            limits:
               memory: 8Gi
 
   workspaces:

--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -18,7 +18,7 @@ metadata:
     pipelines.appstudio.openshift.io/type: build
 
   namespace: rhel-lightspeed-tenant
-  name: digital-roadmap-frontend-push
+  name: digital-roadmap-frontend-on-push
 
 spec:
   params:

--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -47,15 +47,19 @@ spec:
 
   taskRunSpecs:
     - pipelineTaskName: sast-coverity-check
-      stepOverrides:
+      stepSpecs:
         - name: build
           computeResources:
             requests:
+              memory: 8Gi
+            limits:
               memory: 8Gi
 
         - name: postprocess
           computeResources:
             requests:
+              memory: 8Gi
+            limits:
               memory: 8Gi
 
   workspaces:


### PR DESCRIPTION
### Description
Use Tekton API v1 term for overriding task resources.
Rename push pipeline to `-on-push` so that we are able to rerun it if the pipeline fails.
