### PR TITLE
Change API and chrome service port

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,9 @@ In the checkout of this repository, do the following:
 
    ```npm install```
 
-1. Start the application. Set `CHROME_SERVICE=[port number]` if the Chrome service is listening on a port other than the default of 8000.
+1. Start the application. Set `CHROME_SERVICE=[port number]` if the Chrome service is listening on a port other than the default of 8090.
+   Note: The orginal default port of chrome service is 8000 (in case you have to use chrome service in main branch) but this is being used
+   by DR API. The default port of the chrome service is now changed to 8090 due this.
 
    ```npm run start```
 


### PR DESCRIPTION
As the API port got changed due Clowder requirements, default port of the chrome service (now it's used for the API) and of the API needs to be changed.

https://github.com/RedHatInsights/digital-roadmap-backend/pull/61

### Description
<!-- Must include 2-3 sentence summary of proposed changes -->
<!-- Must include links to impacted UI(s) or information regarding the impacted UI -->
<!-- Must include any relevant steps to reproduce (if not clear in tracked issue or story) -->
<!-- Must include RSPEED-XXX link (if proposed change involves tracked issue or story) -->
description text...

Jira link:
[RSPEED-XXX](https://issues.redhat.com/browse/RSPEED-XXX)

---

### Screenshots
<!-- Before and after proposed changes is ideal -->
<!-- Any key UI permutations should be captured -->
<!-- Draw attention to the area of UI that has changed -->
#### Before:


#### After:


---

### Checklist ☑️
- [ ] PR only fixes one issue or story <!-- open new PR for others -->
- [ ] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [ ] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [ ] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [ ] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##
