### PR TITLE
Change branch name to match AppSRE requirement

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,11 +2,11 @@ name: CI
 on:
   push:
     branches:
-      - develop
+      - main
 
   pull_request:
     branches:
-      - develop
+      - main
 
 jobs:
   sanity:

--- a/.tekton/pull-request.yaml
+++ b/.tekton/pull-request.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: >-
       event == "pull_request"
-      && target_branch == "develop"
+      && target_branch == "main"
 
   creationTimestamp: null
 

--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -8,7 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: >-
       event == "push"
-      && target_branch == "develop"
+      && target_branch == "main"
 
   creationTimestamp: null
 


### PR DESCRIPTION
### Description

Change default branch name to `main` since this is required by AppSRE with very little flexibility.