### PR TITLE
[RSPEED-911] Remove "_JAVA_OPTIONS" var from testing-integration

### DIFF
--- a/deploy/testing-integration.yml
+++ b/deploy/testing-integration.yml
@@ -33,7 +33,7 @@ objects:
             defaultMode: 0400
             optional: true
         containers:
-        - name: digital-roadmap-e2e-iqe-${IMAGE_TAG}-${UID} # ???
+        - name: digital-roadmap-e2e-iqe-${IMAGE_TAG}-${UID}
           image: ${IQE_IMAGE}:${IQE_IMAGE_TAG}
           imagePullPolicy: Always
           args:
@@ -108,17 +108,17 @@ objects:
         - name: iqe-sel-${IMAGE_TAG}-${UID}
           image: ${IQE_SEL_IMAGE}
           env:
-            - name: _JAVA_OPTIONS
-              value: ${SELENIUM_JAVA_OPTS}
             - name: VNC_GEOMETRY
               value: ${VNC_GEOMETRY}
+            - name: SE_NODE_MAX_SESSIONS
+              value: ${SE_NODE_MAX_SESSIONS}
           resources:
             limits:
-              cpu: 500m
-              memory: 1.5Gi
+              cpu: ${SELENIUM_CPU_LIMIT}
+              memory: ${SELENIUM_MEMORY_LIMIT}
             requests:
-              cpu: 100m
-              memory: 256Mi
+              cpu: ${SELENIUM_CPU_REQUEST}
+              memory: ${SELENIUM_MEMORY_REQUEST}
           volumeMounts:
             - name: sel-shm
               mountPath: /dev/shm


### PR DESCRIPTION
### Description
Remove the "_JAVA_OPTIONS" parameter from the selenium container as it doesn't exist. Also update some hardcoded values to a variable.

Jira link:
[RSPEED-911](https://issues.redhat.com/browse/RSPEED-911)

---

### Checklist ☑️
- [x] PR only fixes one issue or story <!-- open new PR for others -->
- [x] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [x] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [x] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [x] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##
