### PR TITLE
Hide chart current timeline when no data is given

### DIFF
--- a/src/Components/Lifecycle/Lifecycle.tsx
+++ b/src/Components/Lifecycle/Lifecycle.tsx
@@ -190,7 +190,7 @@ const LifecycleTab: React.FC<React.PropsWithChildren> = () => {
       const appStreams = updateAppLifecycleData(appData.data) || [];
 
       // Check if both data sources are empty
-      if (upcomingChangesParagraphs.length === 0 && appStreams.length === 0) {
+      if (upcomingChangesParagraphs.length === 0 || appStreams.length === 0) {
         setNoDataAvailable(true);
         return;
       }

--- a/src/Components/Lifecycle/Lifecycle.tsx
+++ b/src/Components/Lifecycle/Lifecycle.tsx
@@ -188,13 +188,13 @@ const LifecycleTab: React.FC<React.PropsWithChildren> = () => {
       const appData = await getLifecycleAppstreams();
       const upcomingChangesParagraphs = systemData.data || [];
       const appStreams = updateAppLifecycleData(appData.data) || [];
-      
+
       // Check if both data sources are empty
       if (upcomingChangesParagraphs.length === 0 && appStreams.length === 0) {
         setNoDataAvailable(true);
         return;
       }
-      
+
       setSystemLifecycleChanges(upcomingChangesParagraphs);
       setAppLifecycleChanges(appStreams);
       const updatedSystems = updateLifecycleData(upcomingChangesParagraphs);
@@ -413,7 +413,8 @@ const LifecycleTab: React.FC<React.PropsWithChildren> = () => {
             headingLevel="h2"
           />
           <EmptyStateBody>
-            We couldn't find any Life Cycle data. Either no data exists in the system or there was a problem retrieving it.
+            We couldn't find any Life Cycle data. Either no data exists in the
+            system or there was a problem retrieving it.
           </EmptyStateBody>
           <EmptyStateFooter>
             <EmptyStateActions>

--- a/src/Components/Lifecycle/Lifecycle.tsx
+++ b/src/Components/Lifecycle/Lifecycle.tsx
@@ -413,7 +413,7 @@ const LifecycleTab: React.FC<React.PropsWithChildren> = () => {
             headingLevel="h2"
           />
           <EmptyStateBody>
-            We couldn't find any Life Cycle data. Either no data exists in the
+            We could not find any Life Cycle data. Either no data exists in the
             system or there was a problem retrieving it.
           </EmptyStateBody>
           <EmptyStateFooter>

--- a/src/Components/Lifecycle/Lifecycle.tsx
+++ b/src/Components/Lifecycle/Lifecycle.tsx
@@ -17,6 +17,7 @@ import {
 } from '@patternfly/react-core';
 import { ErrorObject } from '../../types/ErrorObject';
 import SearchIcon from '@patternfly/react-icons/dist/esm/icons/search-icon';
+import CubesIcon from '@patternfly/react-icons/dist/esm/icons/cubes-icon';
 import { getLifecycleAppstreams, getLifecycleSystems } from '../../api';
 import { SystemLifecycleChanges } from '../../types/SystemLifecycleChanges';
 import { Stream } from '../../types/Stream';
@@ -65,6 +66,7 @@ const LifecycleTab: React.FC<React.PropsWithChildren> = () => {
   const [isLoading, setIsLoading] = useState(false);
   const [nameFilter, setNameFilter] = useState<string>('');
   const [error, setError] = useState<ErrorObject>();
+  const [noDataAvailable, setNoDataAvailable] = useState<boolean>(false);
   const [filteredChartData, setFilteredChartData] = useState<
     SystemLifecycleChanges[] | Stream[]
   >([]);
@@ -180,11 +182,19 @@ const LifecycleTab: React.FC<React.PropsWithChildren> = () => {
 
   const fetchData = async () => {
     setIsLoading(true);
+    setNoDataAvailable(false);
     try {
       const systemData = await getLifecycleSystems();
       const appData = await getLifecycleAppstreams();
       const upcomingChangesParagraphs = systemData.data || [];
       const appStreams = updateAppLifecycleData(appData.data) || [];
+      
+      // Check if both data sources are empty
+      if (upcomingChangesParagraphs.length === 0 && appStreams.length === 0) {
+        setNoDataAvailable(true);
+        return;
+      }
+      
       setSystemLifecycleChanges(upcomingChangesParagraphs);
       setAppLifecycleChanges(appStreams);
       const updatedSystems = updateLifecycleData(upcomingChangesParagraphs);
@@ -389,6 +399,31 @@ const LifecycleTab: React.FC<React.PropsWithChildren> = () => {
         errorTitle="Failed to load data"
         errorDescription={String(error.message)}
       />
+    );
+  }
+
+  // New error state for when no data is available
+  if (noDataAvailable) {
+    return (
+      <Bullseye>
+        <EmptyState variant={EmptyStateVariant.lg}>
+          <EmptyStateHeader
+            icon={<EmptyStateIcon icon={CubesIcon} />}
+            titleText="No lifecycle data available"
+            headingLevel="h2"
+          />
+          <EmptyStateBody>
+            We couldn't find any Life Cycle data. Either no data exists in the system or there was a problem retrieving it.
+          </EmptyStateBody>
+          <EmptyStateFooter>
+            <EmptyStateActions>
+              <Button variant="primary" onClick={fetchData}>
+                Try again
+              </Button>
+            </EmptyStateActions>
+          </EmptyStateFooter>
+        </EmptyState>
+      </Bullseye>
     );
   }
 

--- a/src/Components/LifecycleChart/LifecycleChart.tsx
+++ b/src/Components/LifecycleChart/LifecycleChart.tsx
@@ -392,16 +392,18 @@ const LifecycleChart: React.FC<LifecycleChartProps> = ({
             );
           })}
         </ChartGroup>
-        <ChartLine
-          y={() => Date.now()}
-          y0={() => Date.now()}
-          style={{
-            data: {
-              stroke: 'black',
-              strokeWidth: 0.5,
-            },
-          }}
-        />
+        {updatedLifecycleData.length > 0 && (
+          <ChartLine
+            y={() => Date.now()}
+            y0={() => Date.now()}
+            style={{
+              data: {
+                stroke: 'black',
+                strokeWidth: 0.5,
+              },
+            }}
+          />
+        )}
       </Chart>
     </div>
   );

--- a/src/Components/LifecycleChartSystem/LifecycleChartSystem.tsx
+++ b/src/Components/LifecycleChartSystem/LifecycleChartSystem.tsx
@@ -392,16 +392,18 @@ const LifecycleChartSystem: React.FC<LifecycleChartProps> = ({
             );
           })}
         </ChartGroup>
-        <ChartLine
-          y={() => Date.now()}
-          y0={() => Date.now()}
-          style={{
-            data: {
-              stroke: 'black',
-              strokeWidth: 0.5,
-            },
-          }}
-        />
+        {updatedLifecycleData.length > 0 && (
+          <ChartLine
+            y={() => Date.now()}
+            y0={() => Date.now()}
+            style={{
+              data: {
+                stroke: 'black',
+                strokeWidth: 0.5,
+              },
+            }}
+          />
+        )}
       </Chart>
     </div>
   );

--- a/src/Components/Upcoming/Upcoming.tsx
+++ b/src/Components/Upcoming/Upcoming.tsx
@@ -1,11 +1,19 @@
 import './upcoming.scss';
-import React, { lazy, useEffect } from 'react';
+import React, { lazy, useEffect, useState } from 'react';
 import {
   Bullseye,
+  Button,
   Card,
   CardBody,
   CardHeader,
   CardTitle,
+  EmptyState,
+  EmptyStateActions,
+  EmptyStateBody,
+  EmptyStateFooter,
+  EmptyStateHeader,
+  EmptyStateIcon,
+  EmptyStateVariant,
   Grid,
   GridItem,
   Spinner,
@@ -20,6 +28,7 @@ import { ErrorObject } from '../../types/ErrorObject';
 import ExclamationCircleIcon from '@patternfly/react-icons/dist/esm/icons/exclamation-circle-icon';
 import ExclamationTriangleIcon from '@patternfly/react-icons/dist/esm/icons/exclamation-triangle-icon';
 import InfoCircleIcon from '@patternfly/react-icons/dist/esm/icons/info-circle-icon';
+import CubesIcon from '@patternfly/react-icons/dist/esm/icons/cubes-icon';
 import { DEFAULT_FILTERS, buildURL, pluralize } from '../../utils/utils';
 import ErrorState from '@patternfly/react-component-groups/dist/dynamic/ErrorState';
 import { useSearchParams } from 'react-router-dom';
@@ -53,6 +62,7 @@ const UpcomingTab: React.FC<React.PropsWithChildren> = () => {
     string[]
   >([]);
   const [error, setError] = React.useState<ErrorObject>();
+  const [noDataAvailable, setNoDataAvailable] = useState<boolean>(false);
   const [searchParams, setSearchParams] = useSearchParams();
   const [filtersForURL, setFiltersForURL] =
     React.useState<Filter>(DEFAULT_FILTERS);
@@ -86,9 +96,17 @@ const UpcomingTab: React.FC<React.PropsWithChildren> = () => {
 
   const fetchData = async () => {
     setIsLoading(true);
+    setNoDataAvailable(false);
     try {
       const data = await getUpcomingChanges();
       const upcomingChangesParagraphs: UpcomingChanges[] = data || [];
+
+      // Check if  data source is empty
+      if (upcomingChangesParagraphs.length === 0) {
+        setNoDataAvailable(true);
+        return;
+      }
+      
       setUpcomingChanges(upcomingChangesParagraphs);
       const filteredDeprecations = upcomingChangesParagraphs.filter(
         (item) => item.type === 'Deprecation'
@@ -209,6 +227,31 @@ const UpcomingTab: React.FC<React.PropsWithChildren> = () => {
       />
     );
   }
+
+    // New error state for when no data is available
+    if (noDataAvailable) {
+      return (
+        <Bullseye>
+          <EmptyState variant={EmptyStateVariant.lg}>
+            <EmptyStateHeader
+              icon={<EmptyStateIcon icon={CubesIcon} />}
+              titleText="No roadmap data available"
+              headingLevel="h2"
+            />
+            <EmptyStateBody>
+              We couldn't find any Roadmap data. Either no data exists in the system or there was a problem retrieving it.
+            </EmptyStateBody>
+            <EmptyStateFooter>
+              <EmptyStateActions>
+                <Button variant="primary" onClick={fetchData}>
+                  Try again
+                </Button>
+              </EmptyStateActions>
+            </EmptyStateFooter>
+          </EmptyState>
+        </Bullseye>
+      );
+    }
 
   return (
     <Stack className="drf-lifecycle__upcoming" hasGutter>

--- a/src/Components/Upcoming/Upcoming.tsx
+++ b/src/Components/Upcoming/Upcoming.tsx
@@ -239,7 +239,7 @@ const UpcomingTab: React.FC<React.PropsWithChildren> = () => {
             headingLevel="h2"
           />
           <EmptyStateBody>
-            We couldn't find any Roadmap data. Either no data exists in the
+            We could not find any Roadmap data. Either no data exists in the
             system or there was a problem retrieving it.
           </EmptyStateBody>
           <EmptyStateFooter>

--- a/src/Components/Upcoming/Upcoming.tsx
+++ b/src/Components/Upcoming/Upcoming.tsx
@@ -106,7 +106,7 @@ const UpcomingTab: React.FC<React.PropsWithChildren> = () => {
         setNoDataAvailable(true);
         return;
       }
-      
+
       setUpcomingChanges(upcomingChangesParagraphs);
       const filteredDeprecations = upcomingChangesParagraphs.filter(
         (item) => item.type === 'Deprecation'
@@ -228,30 +228,31 @@ const UpcomingTab: React.FC<React.PropsWithChildren> = () => {
     );
   }
 
-    // New error state for when no data is available
-    if (noDataAvailable) {
-      return (
-        <Bullseye>
-          <EmptyState variant={EmptyStateVariant.lg}>
-            <EmptyStateHeader
-              icon={<EmptyStateIcon icon={CubesIcon} />}
-              titleText="No roadmap data available"
-              headingLevel="h2"
-            />
-            <EmptyStateBody>
-              We couldn't find any Roadmap data. Either no data exists in the system or there was a problem retrieving it.
-            </EmptyStateBody>
-            <EmptyStateFooter>
-              <EmptyStateActions>
-                <Button variant="primary" onClick={fetchData}>
-                  Try again
-                </Button>
-              </EmptyStateActions>
-            </EmptyStateFooter>
-          </EmptyState>
-        </Bullseye>
-      );
-    }
+  // New error state for when no data is available
+  if (noDataAvailable) {
+    return (
+      <Bullseye>
+        <EmptyState variant={EmptyStateVariant.lg}>
+          <EmptyStateHeader
+            icon={<EmptyStateIcon icon={CubesIcon} />}
+            titleText="No roadmap data available"
+            headingLevel="h2"
+          />
+          <EmptyStateBody>
+            We couldn't find any Roadmap data. Either no data exists in the
+            system or there was a problem retrieving it.
+          </EmptyStateBody>
+          <EmptyStateFooter>
+            <EmptyStateActions>
+              <Button variant="primary" onClick={fetchData}>
+                Try again
+              </Button>
+            </EmptyStateActions>
+          </EmptyStateFooter>
+        </EmptyState>
+      </Bullseye>
+    );
+  }
 
   return (
     <Stack className="drf-lifecycle__upcoming" hasGutter>


### PR DESCRIPTION
### Description
<!-- Must include 2-3 sentence summary of proposed changes -->
<!-- Must include links to impacted UI(s) or information regarding the impacted UI -->
<!-- Must include any relevant steps to reproduce (if not clear in tracked issue or story) -->
<!-- Must include RSPEED-XXX link (if proposed change involves tracked issue or story) -->
This PR adds a conditional so the ChartLine component that displays the current timeline is only displayed when data is provided to the chart. Additionally empty states have been added for when there is no Roadmap or Lifecycle data returned from a successful api call.

Jira link:
[RSPEED-921](https://issues.redhat.com/browse/RSPEED-921)

---

### Screenshots
<!-- Before and after proposed changes is ideal -->
<!-- Any key UI permutations should be captured -->
<!-- Draw attention to the area of UI that has changed -->
#### Before:


#### After:


---

### Checklist ☑️
- [ ] PR only fixes one issue or story <!-- open new PR for others -->
- [ ] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [ ] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [ ] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [ ] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##
