### PR TITLE
[RSPEED-1036] Add domainPadding to Lifecycle chart

### DIFF
--- a/src/Components/LifecycleChart/LifecycleChart.tsx
+++ b/src/Components/LifecycleChart/LifecycleChart.tsx
@@ -373,7 +373,7 @@ const LifecycleChart: React.FC<LifecycleChartProps> = ({
           right: 75, // Adjusted to accommodate tooltip
           top: 30,
         }}
-        domainPadding={{ x: [1, 1] }}
+        domainPadding={{ x: [13, 13] }}
         height={chartDimensions.height}
         width={chartDimensions.width}
       >

--- a/src/Components/LifecycleChart/LifecycleChart.tsx
+++ b/src/Components/LifecycleChart/LifecycleChart.tsx
@@ -342,7 +342,6 @@ const LifecycleChart: React.FC<LifecycleChartProps> = ({
                 // Add this to fix top and bottom items tooltip behavior
                 pointerOrientation={'bottom'}
                 dx={30}
-                dy={-10}
                 cornerRadius={5}
               />
             }
@@ -364,7 +363,6 @@ const LifecycleChart: React.FC<LifecycleChartProps> = ({
             data={getLegendData()}
             height={50}
             gutter={20}
-            borderPadding={{ top: 5, bottom: 0, left: 10, right: 0 }}
           />
         }
         legendPosition="bottom-left"
@@ -375,6 +373,7 @@ const LifecycleChart: React.FC<LifecycleChartProps> = ({
           right: 75, // Adjusted to accommodate tooltip
           top: 30,
         }}
+        domainPadding={{x:[10,10]}}
         height={chartDimensions.height}
         width={chartDimensions.width}
       >

--- a/src/Components/LifecycleChart/LifecycleChart.tsx
+++ b/src/Components/LifecycleChart/LifecycleChart.tsx
@@ -373,7 +373,7 @@ const LifecycleChart: React.FC<LifecycleChartProps> = ({
           right: 75, // Adjusted to accommodate tooltip
           top: 30,
         }}
-        domainPadding={{x:[10,10]}}
+        domainPadding={{ x: [1, 1] }}
         height={chartDimensions.height}
         width={chartDimensions.width}
       >

--- a/src/Components/LifecycleChartSystem/LifecycleChartSystem.tsx
+++ b/src/Components/LifecycleChartSystem/LifecycleChartSystem.tsx
@@ -332,7 +332,7 @@ const LifecycleChartSystem: React.FC<LifecycleChartProps> = ({
             labelComponent={
               <ChartTooltip
                 constrainToVisibleArea
-                centerOffset={{ x: 160, y: 0 }}
+                centerOffset={{ x: 170, y: 0 }}
                 flyoutStyle={{
                   fill: 'black',
                   stroke: '#888',
@@ -342,7 +342,6 @@ const LifecycleChartSystem: React.FC<LifecycleChartProps> = ({
                 // Add this to fix top and bottom items tooltip behavior
                 pointerOrientation={'bottom'}
                 dx={30}
-                dy={-10}
                 cornerRadius={5}
               />
             }
@@ -350,7 +349,6 @@ const LifecycleChartSystem: React.FC<LifecycleChartProps> = ({
             voronoiPadding={25}
             voronoiDimension="x"
             mouseFollowTooltips
-            activateData
           />
         }
         events={getInteractiveLegendEvents({
@@ -365,7 +363,6 @@ const LifecycleChartSystem: React.FC<LifecycleChartProps> = ({
             data={getLegendData()}
             height={50}
             gutter={20}
-            borderPadding={{ top: 5, bottom: 0, left: 10, right: 0 }}
           />
         }
         legendPosition="bottom-left"
@@ -376,6 +373,7 @@ const LifecycleChartSystem: React.FC<LifecycleChartProps> = ({
           right: 75, // Adjusted to accommodate tooltip
           top: 30,
         }}
+        domainPadding={{x:[10,10]}}
         height={chartDimensions.height}
         width={chartDimensions.width}
       >

--- a/src/Components/LifecycleChartSystem/LifecycleChartSystem.tsx
+++ b/src/Components/LifecycleChartSystem/LifecycleChartSystem.tsx
@@ -373,7 +373,7 @@ const LifecycleChartSystem: React.FC<LifecycleChartProps> = ({
           right: 75, // Adjusted to accommodate tooltip
           top: 30,
         }}
-        domainPadding={{x:[10,10]}}
+        domainPadding={{ x: [10, 10] }}
         height={chartDimensions.height}
         width={chartDimensions.width}
       >

--- a/src/Components/LifecycleChartSystem/LifecycleChartSystem.tsx
+++ b/src/Components/LifecycleChartSystem/LifecycleChartSystem.tsx
@@ -373,7 +373,7 @@ const LifecycleChartSystem: React.FC<LifecycleChartProps> = ({
           right: 75, // Adjusted to accommodate tooltip
           top: 30,
         }}
-        domainPadding={{ x: [10, 10] }}
+        domainPadding={{ x: [13, 13] }}
         height={chartDimensions.height}
         width={chartDimensions.width}
       >


### PR DESCRIPTION
### Description
<!-- Must include 2-3 sentence summary of proposed changes -->
<!-- Must include links to impacted UI(s) or information regarding the impacted UI -->
<!-- Must include any relevant steps to reproduce (if not clear in tracked issue or story) -->
<!-- Must include RSPEED-XXX link (if proposed change involves tracked issue or story) -->
This PR adds the domainPadding attribute to increase the padding at the top and bottom of the chart. This helps with avoiding unwanted hovering when moving from the chart to the legend and removes the bug where a new line is added to the tooltip of the top and bottom items of the chart. 
Jira link:
[RSPEED-1036](https://issues.redhat.com/browse/RSPEED-1036)

---

### Screenshots
<!-- Before and after proposed changes is ideal -->
<!-- Any key UI permutations should be captured -->
<!-- Draw attention to the area of UI that has changed -->
#### Before:
![image](https://github.com/user-attachments/assets/58815ead-f2a1-4bf2-8832-0fb14004e3c5)


#### After:
![image](https://github.com/user-attachments/assets/776e21bf-7fbb-4d04-a1f4-96bb19af733a)


---

### Checklist ☑️
- [ ] PR only fixes one issue or story <!-- open new PR for others -->
- [ ] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [ ] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [ ] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [ ] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##
