### PR TITLE
Update container image build

### DIFF
--- a/.tekton/pipeline-build.yaml
+++ b/.tekton/pipeline-build.yaml
@@ -191,12 +191,6 @@ spec:
           - name: kind
             value: task
 
-      when:
-        - input: $(params.prefetch-input)
-          operator: notin
-          values:
-            - ""
-
       workspaces:
         - name: git-basic-auth
           workspace: git-auth

--- a/.tekton/pipeline-build.yaml
+++ b/.tekton/pipeline-build.yaml
@@ -186,7 +186,7 @@ spec:
             value: prefetch-dependencies-oci-ta
 
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.2@sha256:efc8aebec295bf5986597b6bbeebe093b2764fea79c66094e05ff3d283f54932
+            value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.2@sha256:3a1b3280d6300ebedb9923ddc441b91b6980512be5dae8da4b9d3be21feeb48e
 
           - name: kind
             value: task
@@ -244,7 +244,7 @@ spec:
             value: buildah-oci-ta
 
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.4@sha256:25cd429104fc1e48cf2e4382d9ee475828759649a1e17c913cb8531b4729558b
+            value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.4@sha256:03be9d41b9617edc1436ae5a29cbd130f5101e5031d198f24c463672009754ac
 
           - name: kind
             value: task
@@ -367,7 +367,7 @@ spec:
             value: ecosystem-cert-preflight-checks
 
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.2@sha256:00b13d06d17328e105b11619ee4db98b215ca6ac02314a4776aa5fc2a974f9c1
+            value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.2@sha256:e16e33931bccd678b6b10b87636f37a08a0288b65a662ff76b5dad6fcbbb077f
 
           - name: kind
             value: task
@@ -405,7 +405,7 @@ spec:
             value: sast-snyk-check-oci-ta
 
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check-oci-ta:0.3@sha256:a1cb59ed66a7be1949c9720660efb0a006e95ef05b3f67929dd8e310e1d7baef
+            value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check-oci-ta:0.4@sha256:89aead32dc21404e4e0913be9668bdd2eea795db3e4caa762fb619044e479cb8
 
           - name: kind
             value: task
@@ -520,7 +520,7 @@ spec:
             value: sast-coverity-check-oci-ta
 
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-sast-coverity-check-oci-ta:0.3@sha256:c00535e5363f0fb90a4f6e0026aa1e68d6b10ebc3245a537545e7b99a5d60c6b
+            value: quay.io/konflux-ci/tekton-catalog/task-sast-coverity-check-oci-ta:0.3@sha256:d5e2a69c80a67a14d4bc92dff12b8aa24e68f79996eae23311b774dee978f30f
 
           - name: kind
             value: task
@@ -684,7 +684,7 @@ spec:
             value: rpms-signature-scan
 
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:998b5466417c324aea94d3e8b302c558aeb13f746976d89a4ff85f1b84a42c2b
+            value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:c7c1a5f5534ba22ecb93553632ee9e7c14f8f903dbb2ddde7b265e738686b0ea
 
           - name: kind
             value: task

--- a/.tekton/pipeline-build.yaml
+++ b/.tekton/pipeline-build.yaml
@@ -131,6 +131,12 @@ spec:
         - name: revision
           value: $(params.revision)
 
+        - name: ociStorage
+          value: $(params.output-image).git
+
+        - name: ociArtifactExpiresAfter
+          value: $(params.image-expires-after)
+
       runAfter:
         - init
 
@@ -160,6 +166,15 @@ spec:
       params:
         - name: input
           value: $(params.prefetch-input)
+
+        - name: SOURCE_ARTIFACT
+          value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
+
+        - name: ociStorage
+          value: $(params.output-image).git
+
+        - name: ociArtifactExpiresAfter
+          value: $(params.image-expires-after)
 
       runAfter:
         - clone-repository
@@ -218,6 +233,12 @@ spec:
 
         - name: BUILD_ARGS_FILE
           value: $(params.build-args-file)
+
+        - name: SOURCE_ARTIFACT
+          value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+
+        - name: CACHI2_ARTIFACT
+          value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
 
       runAfter:
         - prefetch-dependencies
@@ -402,6 +423,12 @@ spec:
         - name: image-url
           value: $(tasks.build-image-index.results.IMAGE_URL)
 
+        - name: SOURCE_ARTIFACT
+          value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+
+        - name: CACHI2_ARTIFACT
+          value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+
         - name: ARGS
           value: "--project-name=digital-roadmap-frontend --report --org=12d05a23-73a7-4a1d-9162-ab12e8c051c4"
 
@@ -514,6 +541,12 @@ spec:
         - name: BUILD_ARGS_FILE
           value: $(params.build-args-file)
 
+        - name: SOURCE_ARTIFACT
+          value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+
+        - name: CACHI2_ARTIFACT
+          value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+
       runAfter:
         - coverity-availability-check
 
@@ -548,6 +581,12 @@ spec:
         - name: image-url
           value: $(tasks.build-image-index.results.IMAGE_URL)
 
+        - name: SOURCE_ARTIFACT
+          value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+
+        - name: CACHI2_ARTIFACT
+          value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+
       runAfter:
         - build-image-index
 
@@ -576,6 +615,12 @@ spec:
 
         - name: image-url
           value: $(tasks.build-image-index.results.IMAGE_URL)
+
+        - name: SOURCE_ARTIFACT
+          value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+
+        - name: CACHI2_ARTIFACT
+          value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
 
       runAfter:
         - build-image-index
@@ -636,6 +681,12 @@ spec:
 
         - name: CONTEXT
           value: $(params.path-context)
+
+        - name: SOURCE_ARTIFACT
+          value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+
+        - name: CACHI2_ARTIFACT
+          value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
 
       runAfter:
         - build-image-index

--- a/.tekton/pipeline-build.yaml
+++ b/.tekton/pipeline-build.yaml
@@ -300,37 +300,6 @@ spec:
           values:
             - "true"
 
-    - name: build-source-image
-      params:
-        - name: BINARY_IMAGE
-          value: $(params.output-image)
-
-      runAfter:
-        - build-image-index
-
-      taskRef:
-        resolver: bundles
-        params:
-          - name: name
-            value: source-build-oci-ta
-
-          - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-source-build-oci-ta:0.2@sha256:9fe82c9511f282287686f918bf1a543fcef417848e7a503357e988aab2887cee
-
-          - name: kind
-            value: task
-
-      when:
-        - input: $(tasks.init.results.build)
-          operator: in
-          values:
-            - "true"
-
-        - input: $(params.build-source-image)
-          operator: in
-          values:
-            - "true"
-
     - name: deprecated-base-image-check
       params:
         - name: IMAGE_URL

--- a/.tekton/pipeline-build.yaml
+++ b/.tekton/pipeline-build.yaml
@@ -82,56 +82,6 @@ spec:
       type: array
       default: []
 
-    # Default params for building frontend container file
-    # Avoids having to use the parse-build-deploy-script task
-    - name: component
-      type: string
-      default: digital-roadmap-frontend
-
-    - name: image
-      type: string
-      default: quay.io/redhat-user-workloads/rhel-lightspeed-tenant/digital-roadmap
-
-    - name: node-build-version
-      type: string
-      default: "20"
-
-    - name: quay-expire-time
-      type: string
-      default: ""
-
-    - name: npm-build-script
-      type: string
-      default: ""
-
-    - name: yarn-build-script
-      type: string
-      default: ""
-
-    - name: route-path
-      type: string
-      default: ""
-
-    - name: beta-route-path
-      type: string
-      default: ""
-
-    - name: preview-route-path
-      type: string
-      default: ""
-
-    - name: ci-root
-      type: string
-      default: ""
-
-    - name: server-name
-      type: string
-      default: ""
-
-    - name: dist-folder
-      type: string
-      default: "dist"
-
   results:
     - name: IMAGE_URL
       description: ""
@@ -245,66 +195,6 @@ spec:
         - name: netrc
           workspace: netrc
 
-    - name: create-frontend-containerfile
-      params:
-        - name: path-context
-          value: $(params.path-context)
-
-        - name: component
-          value: $(params.component)
-
-        - name: image
-          value: $(params.image)
-
-        - name: node-build-version
-          value: $(params.node-build-version)
-
-        - name: quay-expire-time
-          value: $(params.quay-expire-time)
-
-        - name: npm-build-script
-          value: $(params.npm-build-script)
-
-        - name: yarn-build-script
-          value: $(params.yarn-build-script)
-
-        - name: route-path
-          value: $(params.route-path)
-
-        - name: beta-route-path
-          value: $(params.beta-route-path)
-
-        - name: preview-route-path
-          value: $(params.preview-route-path)
-
-        - name: ci-root
-          value: $(params.ci-root)
-
-        - name: server-name
-          value: $(params.server-name)
-
-        - name: dist-folder
-          value: $(params.dist-folder)
-
-      taskRef:
-        resolver: git
-        params:
-          - name: url
-            value: https://github.com/RedHatInsights/konflux-consoledot-frontend-build
-
-          - name: revision
-            value: 43aa7592b890acf0b48dce86b49267c179a2aca7
-
-          - name: pathInRepo
-            value: tasks/create-frontend-dockerfile/create-frontend-dockerfile.yaml
-
-      workspaces:
-        - name: source
-          workspace: workspace
-
-      runAfter:
-        - clone-repository
-
     - name: build-container
       params:
         - name: IMAGE
@@ -337,7 +227,6 @@ spec:
 
       runAfter:
         - prefetch-dependencies
-        - create-frontend-containerfile
 
       taskRef:
         resolver: bundles
@@ -653,8 +542,7 @@ spec:
     - name: coverity-availability-check
 
       runAfter:
-        - prefetch-dependencies
-        - create-frontend-containerfile
+        - build-image-index
 
       taskRef:
         resolver: bundles

--- a/.tekton/pipeline-build.yaml
+++ b/.tekton/pipeline-build.yaml
@@ -85,11 +85,11 @@ spec:
   results:
     - name: IMAGE_URL
       description: ""
-      value: $(tasks.build-image-index.results.IMAGE_URL)
+      value: $(tasks.build-container.results.IMAGE_URL)
 
     - name: IMAGE_DIGEST
       description: ""
-      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      value: $(tasks.build-container.results.IMAGE_DIGEST)
 
     - name: CHAINS-GIT_URL
       description: ""
@@ -303,10 +303,10 @@ spec:
     - name: deprecated-base-image-check
       params:
         - name: IMAGE_URL
-          value: $(tasks.build-image-index.results.IMAGE_URL)
+          value: $(tasks.build-container.results.IMAGE_URL)
 
         - name: IMAGE_DIGEST
-          value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+          value: $(tasks.build-container.results.IMAGE_DIGEST)
 
       runAfter:
         - build-image-index
@@ -332,10 +332,10 @@ spec:
     - name: clair-scan
       params:
         - name: image-digest
-          value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+          value: $(tasks.build-container.results.IMAGE_DIGEST)
 
         - name: image-url
-          value: $(tasks.build-image-index.results.IMAGE_URL)
+          value: $(tasks.build-container.results.IMAGE_URL)
 
       runAfter:
         - build-image-index
@@ -361,7 +361,7 @@ spec:
     - name: ecosystem-cert-preflight-checks
       params:
         - name: image-url
-          value: $(tasks.build-image-index.results.IMAGE_URL)
+          value: $(tasks.build-container.results.IMAGE_URL)
 
       runAfter:
         - build-image-index

--- a/.tekton/pipeline-build.yaml
+++ b/.tekton/pipeline-build.yaml
@@ -138,10 +138,10 @@ spec:
         resolver: bundles
         params:
           - name: name
-            value: git-clone
+            value: git-clone-oci-ta
 
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-git-clone:0.1@sha256:3ced9a6b9d8520773d3ffbf062190515a362ecda11e72f56e38e4dd980294b57
+            value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.1@sha256:0761f97595d42c87c076797e0d0f66ff572146cad958106b7f5446b182d03394
 
           - name: kind
             value: task
@@ -153,9 +153,6 @@ spec:
             - "true"
 
       workspaces:
-        - name: output
-          workspace: workspace
-
         - name: basic-auth
           workspace: git-auth
 
@@ -171,10 +168,10 @@ spec:
         resolver: bundles
         params:
           - name: name
-            value: prefetch-dependencies
+            value: prefetch-dependencies-oci-ta
 
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies:0.2@sha256:6a4e6606ac3fa18ca6980f87a135526042833d4b7aaec2e1723272aa70a1d4c1
+            value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.2@sha256:efc8aebec295bf5986597b6bbeebe093b2764fea79c66094e05ff3d283f54932
 
           - name: kind
             value: task
@@ -186,9 +183,6 @@ spec:
             - ""
 
       workspaces:
-        - name: source
-          workspace: workspace
-
         - name: git-basic-auth
           workspace: git-auth
 
@@ -232,10 +226,10 @@ spec:
         resolver: bundles
         params:
           - name: name
-            value: buildah
+            value: buildah-oci-ta
 
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-buildah:0.4@sha256:ad681435bc98dbfe766a1a53555ca40a9437b857db0e348c0f80f23985e7d1db
+            value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.4@sha256:25cd429104fc1e48cf2e4382d9ee475828759649a1e17c913cb8531b4729558b
 
           - name: kind
             value: task
@@ -245,10 +239,6 @@ spec:
           operator: in
           values:
             - "true"
-
-      workspaces:
-        - name: source
-          workspace: workspace
 
     - name: build-image-index
       params:
@@ -301,10 +291,10 @@ spec:
         resolver: bundles
         params:
           - name: name
-            value: source-build
+            value: source-build-oci-ta
 
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-source-build:0.2@sha256:23877bc67736b0e98bb72bb74867ecd7615ad5fa7a1bc236d28726829de611bc
+            value: quay.io/konflux-ci/tekton-catalog/task-source-build-oci-ta:0.2@sha256:9fe82c9511f282287686f918bf1a543fcef417848e7a503357e988aab2887cee
 
           - name: kind
             value: task
@@ -319,10 +309,6 @@ spec:
           operator: in
           values:
             - "true"
-
-      workspaces:
-        - name: workspace
-          workspace: workspace
 
     - name: deprecated-base-image-check
       params:
@@ -426,10 +412,10 @@ spec:
         resolver: bundles
         params:
           - name: name
-            value: sast-snyk-check
+            value: sast-snyk-check-oci-ta
 
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check:0.4@sha256:0d22dbaa528c8edf59aafab3600a0537b5408b80a4f69dd9cb616620795ecdc8
+            value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check-oci-ta:0.3@sha256:a1cb59ed66a7be1949c9720660efb0a006e95ef05b3f67929dd8e310e1d7baef
 
           - name: kind
             value: task
@@ -439,10 +425,6 @@ spec:
           operator: in
           values:
             - "false"
-
-      workspaces:
-        - name: workspace
-          workspace: workspace
 
     - name: clamav-scan
       params:
@@ -463,6 +445,29 @@ spec:
 
           - name: bundle
             value: quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.2@sha256:11b1684965b64f1fa7c65f90a3524413022246a3863eaba188c84eb4bf0b687a
+
+          - name: kind
+            value: task
+
+      when:
+        - input: $(params.skip-checks)
+          operator: in
+          values:
+            - "false"
+
+    - name: coverity-availability-check
+
+      runAfter:
+        - build-image-index
+
+      taskRef:
+        resolver: bundles
+        params:
+          - name: name
+            value: coverity-availability-check
+
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-coverity-availability-check:0.2@sha256:8b58c4fae00c0dfe3937abfb8a9a61aa3c408cca4278b817db53d518428d944e
 
           - name: kind
             value: task
@@ -516,10 +521,10 @@ spec:
         resolver: bundles
         params:
           - name: name
-            value: sast-coverity-check
+            value: sast-coverity-check-oci-ta
 
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-sast-coverity-check:0.3@sha256:3956dbef5a0ba304a8109133c2fcce3d5db2235438ca31919532da451cf809fd
+            value: quay.io/konflux-ci/tekton-catalog/task-sast-coverity-check-oci-ta:0.3@sha256:c00535e5363f0fb90a4f6e0026aa1e68d6b10ebc3245a537545e7b99a5d60c6b
 
           - name: kind
             value: task
@@ -534,33 +539,6 @@ spec:
           operator: in
           values:
             - success
-
-      workspaces:
-        - name: source
-          workspace: workspace
-
-    - name: coverity-availability-check
-
-      runAfter:
-        - build-image-index
-
-      taskRef:
-        resolver: bundles
-        params:
-          - name: name
-            value: coverity-availability-check
-
-          - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-coverity-availability-check:0.2@sha256:8b58c4fae00c0dfe3937abfb8a9a61aa3c408cca4278b817db53d518428d944e
-
-          - name: kind
-            value: task
-
-      when:
-        - input: $(params.skip-checks)
-          operator: in
-          values:
-            - "false"
 
     - name: sast-shell-check
       params:
@@ -577,10 +555,10 @@ spec:
         resolver: bundles
         params:
           - name: name
-            value: sast-shell-check
+            value: sast-shell-check-oci-ta
 
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-sast-shell-check:0.1@sha256:188a4f6a582ac43d4de46c3998ded3c2a8ee237fb0604d90559a3b6e0aa62b0f
+            value: quay.io/konflux-ci/tekton-catalog/task-sast-shell-check-oci-ta:0.1@sha256:57b3262138eb06186ae7375f84ca53788bba2a66cfd03d39cb82c78df050aba5
 
           - name: kind
             value: task
@@ -590,10 +568,6 @@ spec:
           operator: in
           values:
             - "false"
-
-      workspaces:
-        - name: workspace
-          workspace: workspace
 
     - name: sast-unicode-check
       params:
@@ -610,10 +584,10 @@ spec:
         resolver: bundles
         params:
           - name: name
-            value: sast-unicode-check
+            value: sast-unicode-check-oci-ta
 
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-sast-unicode-check:0.2@sha256:e4a5215b45b1886a185a9db8ab392f8440c2b0848f76d719885637cf8d2628ed
+            value: quay.io/konflux-ci/tekton-catalog/task-sast-unicode-check-oci-ta:0.2@sha256:df185dbe4e2852668f9c46f938dd752e90ea9c79696363378435a6499596c319
 
           - name: kind
             value: task
@@ -623,10 +597,6 @@ spec:
           operator: in
           values:
             - "false"
-
-      workspaces:
-        - name: workspace
-          workspace: workspace
 
     - name: apply-tags
       params:
@@ -674,17 +644,13 @@ spec:
         resolver: bundles
         params:
           - name: name
-            value: push-dockerfile
+            value: push-dockerfile-oci-ta
 
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile:0.1@sha256:6124587dffebd15b2123f73ca25807c5e69ff349489b31d4af6ff46a5d0228d6
+            value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.1@sha256:c4f87c44c4cf99f3d90435d72ad93e550b14d2928ba943715daf9015bcc1af73
 
           - name: kind
             value: task
-
-      workspaces:
-        - name: workspace
-          workspace: workspace
 
     - name: rpms-signature-scan
       params:
@@ -733,40 +699,7 @@ spec:
           - name: kind
             value: task
 
-    - name: show-summary
-      params:
-        - name: pipelinerun-name
-          value: $(context.pipelineRun.name)
-
-        - name: git-url
-          value: $(tasks.clone-repository.results.url)?rev=$(tasks.clone-repository.results.commit)
-
-        - name: image-url
-          value: $(params.output-image)
-
-        - name: build-task-status
-          value: $(tasks.build-image-index.status)
-
-      taskRef:
-        resolver: bundles
-        params:
-          - name: name
-            value: summary
-
-          - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-summary:0.2@sha256:870d9a04d9784840a90b7bf6817cd0d0c4edfcda04b1ba1868cae625a3c3bfcc
-
-          - name: kind
-            value: task
-
-      workspaces:
-        - name: workspace
-          workspace: workspace
-
-
   workspaces:
-    - name: workspace
-
     - name: git-auth
       optional: true
 

--- a/.tekton/pull-request.yaml
+++ b/.tekton/pull-request.yaml
@@ -65,16 +65,3 @@ spec:
     - name: git-auth
       secret:
         secretName: '{{ git_auth_secret }}'
-
-    - name: workspace
-      volumeClaimTemplate:
-        metadata:
-          creationTimestamp: null
-
-        spec:
-          accessModes:
-            - ReadWriteOnce
-
-          resources:
-            requests:
-              storage: 1Gi

--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -66,16 +66,3 @@ spec:
     - name: git-auth
       secret:
         secretName: '{{ git_auth_secret }}'
-
-    - name: workspace
-      volumeClaimTemplate:
-        metadata:
-          creationTimestamp: null
-
-        spec:
-          accessModes:
-            - ReadWriteOnce
-
-          resources:
-            requests:
-              storage: 1Gi

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM registry.access.redhat.com/ubi9/nodejs-22:9.5-1742955796 as builder
+
+USER root
+
+RUN dnf install jq -y
+
+USER default
+
+RUN npm i -g yarn
+
+COPY build/*.sh /opt/app-root/bin/
+COPY --chown=default . .
+
+RUN universal_build.sh
+
+FROM quay.io/redhat-services-prod/hcm-eng-prod-tenant/caddy-ubi:latest
+
+COPY LICENSE /licenses/
+
+ENV CADDY_TLS_MODE http_port 8000
+
+COPY --from=builder /opt/app-root/src/Caddyfile /etc/caddy/Caddyfile
+COPY --from=builder /opt/app-root/src/dist dist
+COPY package.json .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/nodejs-22:9.5-1742955796 as builder
+FROM registry.access.redhat.com/ubi9/nodejs-20:9.5 as builder
 
 USER root
 

--- a/build/build_app_info.sh
+++ b/build/build_app_info.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+
+# ----------------------------------------------------------------------------
+# Script Name: build_app_info.sh
+# Description: outputs to STDOUT a JSON containing various
+#              pieces of information about a Node.js application and its
+#              dependencies. The generated JSON includes the application
+#              name, Node.js version, source hash, source tag, source branch,
+#              PatternFly dependencies, and Red Hat Cloud Services
+#              dependencies, gleaned from the git environment and package.json.
+#
+# Usage:       ./build_app_info.sh
+#
+# Parameters:  None
+#
+# Dependencies: The script requires `jq` and `node` to be installed, and expects
+#               to be run in a git repository directory to extract certain
+#               pieces of source information.
+# ----------------------------------------------------------------------------
+
+get_package_value() {
+  local key="$1"
+
+  jq ".${key} // \"unknown\" " --raw-output < package.json
+}
+
+# handle_npm_list
+# Purpose: Retrieve a comma-separated list of dependency versions for a given scope.
+# Parameters:
+#   - dependency_scope: A string to grep for in the npm list, e.g. a scope or package name.
+# Usage: handle_npm_list <dependency_scope>
+# Example: handle_npm_list "@patternfly"
+handle_npm_list() {
+  local dependency_scope="$1"
+
+  # Check if a lock file exists, suggesting that the node_modules directory is present.
+  if [[ -f package-lock.json ]] || [[ -f yarn.lock ]]; then
+    # Retrieve and format the dependency list. If unsuccessful, return an empty string.
+    local dep_list
+    dep_list=$(npm list --silent --depth=0 --production | grep "$dependency_scope" -i | sed -E "s/^(.{0})(.{4})/\1/" | tr "\n" "," | sed -E "s/,/\",\"/g" || echo "")
+
+    # Check if the dependency list is empty and log an error message if so.
+    if [[ -z "$dep_list" ]]; then
+      echo "Error: No dependencies matching '$dependency_scope' found." >&2
+      echo "" # Return an empty string as the function result.
+    else
+      echo "$dep_list"
+    fi
+  else
+    # If no lock file is present, log an error message and return an empty string.
+    echo "Error: No package-lock.json or yarn.lock file found. Cannot retrieve dependency list for '$dependency_scope'." >&2
+    echo ""
+  fi
+}
+
+get_git_branch() {
+  # Retrieve the current Git branch name or return "unknown" if unsuccessful.
+  if ! git branch --show-current 2>/dev/null; then
+    echo "unknown"
+  fi
+}
+
+get_git_tag() {
+  # Retrieve the current Git tag or return "unknown" if unsuccessful.
+  if ! git describe --tags --abbrev=0 2>/dev/null; then
+    echo "unknown"
+  fi
+}
+
+get_git_hash() {
+  if ! git rev-parse --verify HEAD 2>/dev/null; then
+    echo "unknown"
+  fi
+}
+
+SRC_HASH=$(get_git_hash)
+APP_NAME=$(get_package_value "insights.appname")
+NODE_VERSION=$(get_package_value "engines.node")
+SRC_BRANCH=$(get_git_branch)
+SRC_TAG=$(get_git_tag)
+
+PATTERNFLY_DEPS=$(handle_npm_list "@patternfly")
+RH_CLOUD_SERVICES_DEPS=$(handle_npm_list "@redhat-cloud-services")
+PATTERNFLY_DEPS="[\"${PATTERNFLY_DEPS%???}\"]"
+RH_CLOUD_SERVICES_DEPS="[\"${RH_CLOUD_SERVICES_DEPS%???}\"]"
+
+# JSON generation with `jq`
+jq -n \
+  --arg an "$APP_NAME" \
+  --arg nv "$NODE_VERSION" \
+  --arg sh "$SRC_HASH" \
+  --arg st "$SRC_TAG" \
+  --arg sb "$SRC_BRANCH" \
+  --arg pd "$PATTERNFLY_DEPS" \
+  --arg rh "$RH_CLOUD_SERVICES_DEPS" \
+  '{
+    app_name: $an,
+    node_version: $nv,
+    src_hash: $sh,
+    src_tag: $st,
+    src_branch: $sb,
+    patternfly_dependencies: $pd,
+    rh_cloud_services_dependencies: $rh
+  }'

--- a/build/server_config_gen.sh
+++ b/build/server_config_gen.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+
+export LC_ALL=en_US.utf-8
+export LANG=en_US.utf-8
+export GIT_COMMIT=$(git rev-parse HEAD)
+
+NPM_INFO="undefined"
+PATTERNFLY_DEPS="undefined"
+export USES_CADDY=true
+SERVER_NAME=${SERVER_NAME:-$APP_NAME}
+
+generate_caddy_config() {
+
+  local ROUTE_PATH=${ROUTE_PATH:-"/apps/${APP_NAME}"}
+
+  echo "{
+	{\$CADDY_TLS_MODE}
+	auto_https disable_redirects
+	servers {
+		metrics
+	}
+}
+
+:9000 {
+	metrics /metrics
+}
+
+:8000 {
+	{\$CADDY_TLS_CERT}
+	log
+
+	# Handle main app route
+	@app_match {
+		path ${ROUTE_PATH}*
+	}
+	handle @app_match {
+		uri strip_prefix ${ROUTE_PATH}
+		file_server * {
+			root /srv/${OUTPUT_DIR}
+			browse
+		}
+	}
+
+	handle / {
+		redir /apps/chrome/index.html permanent
+	}
+}"
+}
+
+generate_docker_ignore() {
+  cat << EOF
+node_modules
+.git
+EOF
+}
+
+# FIXME: How's this any different from the "build_app_info.sh script??"
+generate_app_info() {
+  if [[ -f package-lock.json ]] || [[ -f yarn.lock ]]; then
+    LINES=$(npm list --silent --depth=0 --production | grep @patternfly -i | sed -E "s/^(.{0})(.{4})/\1/" | tr "\n" "," | sed -E "s/,/\",\"/g")
+    PATTERNFLY_DEPS="[\"${LINES%???}\"]"
+    LINES=$(npm list --silent --depth=0 --production | grep @redhat-cloud-services -i | sed -E "s/^(.{0})(.{4})/\1/" | tr "\n" "," | sed -E "s/,/\",\"/g")
+    RH_CLOUD_SERVICES_DEPS="[\"${LINES%???}\"]"
+  else
+    PATTERNFLY_DEPS="[]"
+    RH_CLOUD_SERVICES_DEPS="[]"
+  fi
+
+  echo -n "{
+  \"app_name\": \"$APP_NAME\",
+  \"src_hash\": \"$GIT_COMMIT\",
+  \"patternfly_dependencies\": $PATTERNFLY_DEPS,
+  \"rh_cloud_services_dependencies\": $RH_CLOUD_SERVICES_DEPS
+  }"
+}
+
+# Now we check for a Caddyfile and if it's correct to generate
+if [[ -f Caddyfile ]]; then
+    echo "Caddy config already exists, skipping generation"
+else
+    generate_caddy_config > Caddyfile;
+fi
+
+if [[ -f .dockerignore ]]; then
+  echo "Docker ignore already exists, skipping generation"
+else
+  generate_docker_ignore > .dockerignore
+fi
+
+
+if [[ -n "${APP_BUILD_DIR:-}" &&  -d $APP_BUILD_DIR ]]; then
+  OUTPUT_DIR="$APP_BUILD_DIR"
+fi
+
+if [[ -f "${OUTPUT_DIR}/app.info.deps.json" ]]; then
+  echo "app.info.deps.json already exists, skipping generation"
+else
+  echo $NPM_INFO > "${OUTPUT_DIR}/app.info.deps.json"
+fi
+
+if [[ -f "${OUTPUT_DIR}/app.info.json" ]]; then
+  echo "app.info.json already exists, skipping generation"
+else
+  generate_app_info > "${OUTPUT_DIR}/app.info.json"
+fi

--- a/build/universal_build.sh
+++ b/build/universal_build.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+
+set -exv
+
+export OUTPUT_DIR=${OUTPUT_DIR:-dist}
+
+function install() {
+  if [ $USES_NPM == true ]; then
+    npm ci
+  elif [ $USES_YARN == true ]; then
+    yarn install --immutable
+  else
+    # Normally we would not use exit in a source'd file, but this should fail the job
+    echo "Exiting; no supported installation packages"
+    exit 1
+  fi
+}
+
+function verify() {
+  if [ $USES_NPM == true ]; then
+    npm run verify
+  elif [ $USES_YARN == true ]; then
+    yarn verify
+  else
+    # Normally we would not use exit in a source'd file, but this should fail the job
+    echo "Exiting; no supported verification tool or target"
+    exit 1
+  fi
+}
+
+function build() {
+  if [[ "$USES_NPM" == true ]]; then
+    # If NPM_BUILD_SCRIPT env var is set use that
+    # Otherwise just build
+    if [[ -n "$NPM_BUILD_SCRIPT" ]]; then
+      npm run "$NPM_BUILD_SCRIPT"
+    else
+      npm run build
+    fi
+  elif [[ "$USES_YARN" == true ]]; then
+    # If YARN_BUILD_SCRIPT env var is set use that
+    # Otherwise just build
+    if [[ -n "$YARN_BUILD_SCRIPT" ]]; then
+      yarn "$YARN_BUILD_SCRIPT"
+    else
+      yarn build:prod
+    fi
+  else
+    # Normally we would not use exit in a source'd file, but this should fail the job
+    echo "Exiting; no supported build or target"
+    exit 1
+  fi
+}
+
+function delete_node_modules() {
+  if [[ -d "node_modules" ]]; then
+    rm -rf node_modules
+  else
+    echo "node_modules directory not found."
+  fi
+}
+
+function setNpmOrYarn() {
+  # We can't assume npm or yarn, so we turn on the toggle depending on files in the root
+  if [[ -f package-lock.json ]]; then
+    USES_NPM=true
+  elif [[ -f yarn.lock ]]; then
+    USES_YARN=true
+  else
+  # Normally we would not use exit in a source'd file, but this should fail the job
+    echo "Exiting; no yarn or npm package lock files found. Add a package-lock.json or yarn.lock to your project root"
+    exit 1
+  fi
+}
+
+get_appname_from_package() {
+  jq --raw-output '.insights.appname' < package.json
+}
+
+# Work around large package timeout; up default from 30s to 5m
+yarn config set network-timeout 300000
+
+if ! APP_NAME=$(get_appname_from_package); then
+  echo "could not read application name from package.json"
+  exit 1
+fi
+
+export APP_NAME
+
+setNpmOrYarn
+
+install
+
+export BETA=false
+build
+build_app_info.sh > "${OUTPUT_DIR}/app.info.json"
+server_config_gen.sh


### PR DESCRIPTION
### Description
Changes in the Konflux enterprise contract require moving to a new base image. This in turn meant retooling the existing build pipeline to move away from generating a containerfile to including a containerfile and all accompanying build tools in the repo.

This is ultimately cleaner and something I've been putting off doing for a while.

The image is now built using trusted artifacts instead of workspaces.
