### PR TITLE
[RSPEED-1113] Styling roadmap tab

### DIFF
--- a/src/Components/Upcoming/Upcoming.tsx
+++ b/src/Components/Upcoming/Upcoming.tsx
@@ -246,7 +246,7 @@ const UpcomingTab: React.FC<React.PropsWithChildren> = () => {
       <StackItem>
         <Grid hasGutter span={12}>
           <GridItem span={4}>
-            <Card ouiaId="upcoming-deprecations" isClickable>
+            <Card ouiaId="upcoming-deprecations" isClickable style={{ height: '135px' }}>
               <CardHeader
                 selectableActions={{
                   onClickAction: () => handleCardClick('deprecations'),
@@ -267,7 +267,7 @@ const UpcomingTab: React.FC<React.PropsWithChildren> = () => {
             </Card>
           </GridItem>
           <GridItem span={4}>
-            <Card ouiaId="upcoming-changes" isClickable>
+            <Card ouiaId="upcoming-changes" isClickable style={{ height: '135px' }}>
               <CardHeader
                 selectableActions={{
                   onClickAction: () => handleCardClick('changes'),
@@ -288,7 +288,7 @@ const UpcomingTab: React.FC<React.PropsWithChildren> = () => {
             </Card>
           </GridItem>
           <GridItem span={4}>
-            <Card ouiaId="upcoming-additions" isClickable>
+            <Card ouiaId="upcoming-additions" isClickable style={{ height: '135px' }}>
               <CardHeader
                 selectableActions={{
                   onClickAction: () => handleCardClick('additions'),

--- a/src/Components/UpcomingRow/UpcomingRow.scss
+++ b/src/Components/UpcomingRow/UpcomingRow.scss
@@ -20,25 +20,3 @@
   align-items: center;
   gap: 8px;
 }
-
-/* Control the width of the expand column */
-.drf-lifecycle__expand-column {
-  width: 30px !important;
-  min-width: 30px !important;
-  max-width: 30px !important;
-}
-
-/* Ensure Name column has proper width */
-.drf-lifecycle__name-column {
-  min-width: 250px; /* Set a minimum width */
-}
-
-/* Hide any extra dots or visual issues */
-.pf-c-table__toggle-icon {
-  margin-right: 0 !important;
-}
-
-/* Ensure proper spacing in the table */
-.pf-c-table tr > * {
-  vertical-align: middle;
-}

--- a/src/Components/UpcomingRow/UpcomingRow.scss
+++ b/src/Components/UpcomingRow/UpcomingRow.scss
@@ -20,3 +20,25 @@
   align-items: center;
   gap: 8px;
 }
+
+/* Control the width of the expand column */
+.drf-lifecycle__expand-column {
+  width: 30px !important;
+  min-width: 30px !important;
+  max-width: 30px !important;
+}
+
+/* Ensure Name column has proper width */
+.drf-lifecycle__name-column {
+  min-width: 250px; /* Set a minimum width */
+}
+
+/* Hide any extra dots or visual issues */
+.pf-c-table__toggle-icon {
+  margin-right: 0 !important;
+}
+
+/* Ensure proper spacing in the table */
+.pf-c-table tr > * {
+  vertical-align: middle;
+}

--- a/src/Components/UpcomingRow/UpcomingRow.tsx
+++ b/src/Components/UpcomingRow/UpcomingRow.tsx
@@ -98,12 +98,10 @@ export const TableRow: React.FunctionComponent<TableRowProps> = ({
               onToggle,
               expandId: 'composable-expandable-example',
             }}
-            className="drf-lifecycle__expand-column"
           />
           <Td
             dataLabel={columnNames.name}
             width={15} // Increase width of Name column
-            className="drf-lifecycle__name-column"
           >
             {repo.name}
           </Td>

--- a/src/Components/UpcomingRow/UpcomingRow.tsx
+++ b/src/Components/UpcomingRow/UpcomingRow.tsx
@@ -91,15 +91,22 @@ export const TableRow: React.FunctionComponent<TableRowProps> = ({
     <>
       <Tbody isExpanded={isExpanded}>
         <Tr>
-          <Td
-            expand={{
-              rowIndex: rowIndex,
-              isExpanded,
-              onToggle,
-              expandId: 'composable-expandable-example',
-            }}
-          />
-          <Td dataLabel={columnNames.name} modifier="truncate">
+        <Td
+          expand={{
+            rowIndex: rowIndex,
+            isExpanded,
+            onToggle,
+            expandId: 'composable-expandable-example',
+          }}
+          className="drf-lifecycle__expand-column"
+          style={{ width: '30px' }} /* Control the width of expand column */
+        />
+          <Td 
+            dataLabel={columnNames.name} 
+            modifier="truncate" 
+            width={40} // Increase width of Name column
+            className="drf-lifecycle__name-column"
+          >
             {repo.name}
           </Td>
           <Td dataLabel={columnNames.type} modifier="truncate">
@@ -163,24 +170,6 @@ export const TableRow: React.FunctionComponent<TableRowProps> = ({
                     <TextListItem component={TextListItemVariants.dd}>{repo.details.lastModified}</TextListItem>
                   </TextList>
                 </TextContent>
-                {/* 
-                <TextContent>
-                  <TextList component={TextListVariants.dl}>
-                    <TextListItem component={TextListItemVariants.dt}>Date added                    {""}</TextListItem>
-                    <TextListItem component={TextListItemVariants.dd}>
-                      {repo.details.dateAdded}
-                    </TextListItem>
-                  </TextList>
-                </TextContent>
-
-                <TextContent>
-                 <TextList component={TextListVariants.dl}>
-                  <TextListItem component={TextListItemVariants.dt}>Last modified</TextListItem>
-                  <TextListItem component={TextListItemVariants.dd}>
-                      {repo.details.lastModified}
-                  </TextListItem>
-                 </TextList>
-                </TextContent> */}
               </div>
             </Td>
           </Tr>

--- a/src/Components/UpcomingRow/UpcomingRow.tsx
+++ b/src/Components/UpcomingRow/UpcomingRow.tsx
@@ -157,7 +157,7 @@ export const TableRow: React.FunctionComponent<TableRowProps> = ({
                         {repo.details.potentiallyAffectedSystems}
                       </Button>
                     </TextListItem>
-                    <TextListItem component={TextListItemVariants.dt}>Training ticket</TextListItem>
+                    <TextListItem component={TextListItemVariants.dt}>Tracking ticket</TextListItem>
                     <TextListItem component={TextListItemVariants.dd}>
                       <a href={`https://issues.redhat.com/browse/${repo.details.trainingTicket}`} rel="noreferrer">
                         {repo.details.trainingTicket}

--- a/src/Components/UpcomingRow/UpcomingRow.tsx
+++ b/src/Components/UpcomingRow/UpcomingRow.tsx
@@ -91,20 +91,19 @@ export const TableRow: React.FunctionComponent<TableRowProps> = ({
     <>
       <Tbody isExpanded={isExpanded}>
         <Tr>
-        <Td
-          expand={{
-            rowIndex: rowIndex,
-            isExpanded,
-            onToggle,
-            expandId: 'composable-expandable-example',
-          }}
-          className="drf-lifecycle__expand-column"
-          style={{ width: '30px' }} /* Control the width of expand column */
-        />
-          <Td 
-            dataLabel={columnNames.name} 
-            modifier="truncate" 
-            width={40} // Increase width of Name column
+          <Td
+            expand={{
+              rowIndex: rowIndex,
+              isExpanded,
+              onToggle,
+              expandId: 'composable-expandable-example',
+            }}
+            className="drf-lifecycle__expand-column"
+          />
+          <Td
+            dataLabel={columnNames.name}
+            modifier="truncate"
+            width={15} // Increase width of Name column
             className="drf-lifecycle__name-column"
           >
             {repo.name}

--- a/src/Components/UpcomingRow/UpcomingRow.tsx
+++ b/src/Components/UpcomingRow/UpcomingRow.tsx
@@ -102,7 +102,6 @@ export const TableRow: React.FunctionComponent<TableRowProps> = ({
           />
           <Td
             dataLabel={columnNames.name}
-            modifier="truncate"
             width={15} // Increase width of Name column
             className="drf-lifecycle__name-column"
           >


### PR DESCRIPTION
### Description
<!-- Must include 2-3 sentence summary of proposed changes -->
<!-- Must include links to impacted UI(s) or information regarding the impacted UI -->
<!-- Must include any relevant steps to reproduce (if not clear in tracked issue or story) -->
<!-- Must include RSPEED-XXX link (if proposed change involves tracked issue or story) -->
This PR contains the following changes:

- Increase the width of the "Name" column relative to the the other three columns. 

- Change “Training ticket” to “Tracking ticket”

- Make all three filter cards the same height (equal to the tallest), even if there are a different number of body text lines within them.

Jira link:
[RSPEED-1113](https://issues.redhat.com/browse/RSPEED-1113)

---

### Screenshots
<!-- Before and after proposed changes is ideal -->
<!-- Any key UI permutations should be captured -->
<!-- Draw attention to the area of UI that has changed -->
#### Before:
![image](https://github.com/user-attachments/assets/6abb7fb3-1eb1-4646-be69-2751b255c681)


#### After:
![image](https://github.com/user-attachments/assets/5cf73e70-a606-4ccc-884d-edbf1dd53d2c)


---

### Checklist ☑️
- [ ] PR only fixes one issue or story <!-- open new PR for others -->
- [ ] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [ ] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [ ] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [ ] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##
