### PR TITLE
[RSPEED-1121] Make the left padding of the Chart dynamic

### DIFF
--- a/src/Components/LifecycleChart/LifecycleChart.tsx
+++ b/src/Components/LifecycleChart/LifecycleChart.tsx
@@ -343,6 +343,30 @@ const LifecycleChart: React.FC<LifecycleChartProps> = ({ lifecycleData }: Lifecy
     };
   }, [updatedLifecycleData.length]);
 
+  // Calculate padding based on the longest name
+  const calculateLeftPadding = () => {
+    if (updatedLifecycleData.length === 0) {
+      return 160; // Default padding if no data
+    }
+    
+    // Get all names
+    const names = updatedLifecycleData.map(data => data[0].x);
+    
+    // Find the longest name
+    const longestName = names.reduce((longest, current) => 
+      current.length > longest.length ? current : longest, '');
+    
+    // Calculate padding: base padding (120) + character count * character width factor
+    const charWidthFactor = 6;
+    const basePadding = 60;
+    const calculatedPadding = basePadding + (longestName.length * charWidthFactor);
+    
+    // Set a minimum and maximum boundary
+    return Math.max(160, Math.min(calculatedPadding, 250));
+  };
+
+  const leftPadding = calculateLeftPadding();
+
   // Explicitly return the entire div structure
   return (
     <div className="drf-lifecycle__chart" tabIndex={0} ref={chartContainerRef}>
@@ -361,7 +385,7 @@ const LifecycleChart: React.FC<LifecycleChartProps> = ({ lifecycleData }: Lifecy
         name="chart5"
         padding={{
           bottom: 60, // Adjusted to accommodate legend
-          left: 180,
+          left: leftPadding, // Dynamically calculated based on the longest name
           right: 75, // Adjusted to accommodate tooltip
           top: 30,
         }}

--- a/src/Components/LifecycleChart/LifecycleChart.tsx
+++ b/src/Components/LifecycleChart/LifecycleChart.tsx
@@ -348,19 +348,21 @@ const LifecycleChart: React.FC<LifecycleChartProps> = ({ lifecycleData }: Lifecy
     if (updatedLifecycleData.length === 0) {
       return 160; // Default padding if no data
     }
-    
+
     // Get all names
-    const names = updatedLifecycleData.map(data => data[0].x);
-    
+    const names = updatedLifecycleData.map((data) => data[0].x);
+
     // Find the longest name
-    const longestName = names.reduce((longest, current) => 
-      current.length > longest.length ? current : longest, '');
-    
-    // Calculate padding: base padding (120) + character count * character width factor
+    const longestName = names.reduce(
+      (longest, current) => (current.length > longest.length ? current : longest),
+      ''
+    );
+
+    // Calculate padding: base padding (60) + character count * character width factor
     const charWidthFactor = 6;
     const basePadding = 60;
-    const calculatedPadding = basePadding + (longestName.length * charWidthFactor);
-    
+    const calculatedPadding = basePadding + longestName.length * charWidthFactor;
+
     // Set a minimum and maximum boundary
     return Math.max(160, Math.min(calculatedPadding, 250));
   };

--- a/src/Components/LifecycleChart/LifecycleChart.tsx
+++ b/src/Components/LifecycleChart/LifecycleChart.tsx
@@ -364,7 +364,7 @@ const LifecycleChart: React.FC<LifecycleChartProps> = ({ lifecycleData }: Lifecy
     const calculatedPadding = basePadding + longestName.length * charWidthFactor;
 
     // Set a minimum and maximum boundary
-    return Math.max(160, Math.min(calculatedPadding, 250));
+    return Math.max(160, Math.min(calculatedPadding, 400));
   };
 
   const leftPadding = calculateLeftPadding();

--- a/src/Components/LifecycleChartSystem/LifecycleChartSystem.tsx
+++ b/src/Components/LifecycleChartSystem/LifecycleChartSystem.tsx
@@ -46,7 +46,7 @@ const LifecycleChartSystem: React.FC<LifecycleChartProps> = ({ lifecycleData }: 
     if (!lifecycleData || lifecycleData.length === 0) {
       return '';
     }
-    if ('stream' in lifecycleData[0]) {
+    if ('application_stream_name' in lifecycleData[0]) {
       return 'appLifecycle';
     }
     return 'lifecycle';
@@ -138,7 +138,7 @@ const LifecycleChartSystem: React.FC<LifecycleChartProps> = ({ lifecycleData }: 
           return;
         }
         formatChartData(
-          item.display_name,
+          `${item.display_name}`,
           item.start_date,
           item.end_date,
           item.support_status,
@@ -343,6 +343,32 @@ const LifecycleChartSystem: React.FC<LifecycleChartProps> = ({ lifecycleData }: 
     };
   }, [updatedLifecycleData.length]);
 
+  // Calculate padding based on the longest name
+  const calculateLeftPadding = () => {
+    if (updatedLifecycleData.length === 0) {
+      return 160; // Default padding if no data
+    }
+
+    // Get all names
+    const names = updatedLifecycleData.map((data) => data[0].x);
+
+    // Find the longest name
+    const longestName = names.reduce(
+      (longest, current) => (current.length > longest.length ? current : longest),
+      ''
+    );
+
+    // Calculate padding: base padding (60) + character count * character width factor
+    const charWidthFactor = 6;
+    const basePadding = 60;
+    const calculatedPadding = basePadding + longestName.length * charWidthFactor;
+
+    // Set a minimum and maximum boundary
+    return Math.max(160, Math.min(calculatedPadding, 250));
+  };
+
+  const leftPadding = calculateLeftPadding();
+
   // Explicitly return the entire div structure
   return (
     <div className="drf-lifecycle__chart" tabIndex={0} ref={chartContainerRef}>
@@ -361,7 +387,7 @@ const LifecycleChartSystem: React.FC<LifecycleChartProps> = ({ lifecycleData }: 
         name="chart5"
         padding={{
           bottom: 60, // Adjusted to accommodate legend
-          left: 180,
+          left: leftPadding, // Dynamically calculated based on the longest name
           right: 75, // Adjusted to accommodate tooltip
           top: 30,
         }}
@@ -507,7 +533,7 @@ const LifecycleChartSystem: React.FC<LifecycleChartProps> = ({ lifecycleData }: 
                           setTooltipData(null);
                           return {
                             style: {
-                              stroke: 'black',
+                              stroke: '#151515',
                               strokeWidth: 2,
                             },
                           };


### PR DESCRIPTION
### Description
<!-- Must include 2-3 sentence summary of proposed changes -->
<!-- Must include links to impacted UI(s) or information regarding the impacted UI -->
<!-- Must include any relevant steps to reproduce (if not clear in tracked issue or story) -->
<!-- Must include RSPEED-XXX link (if proposed change involves tracked issue or story) -->
This PR adjusts the left padding of the chart based on the longest name in the y axis to accommodate displaying longer names.
Jira link:
[RSPEED-1121](https://issues.redhat.com/browse/RSPEED-1121)

---

### Screenshots
<!-- Before and after proposed changes is ideal -->
<!-- Any key UI permutations should be captured -->
<!-- Draw attention to the area of UI that has changed -->
#### Before:


#### After:


---

### Checklist ☑️
- [ ] PR only fixes one issue or story <!-- open new PR for others -->
- [ ] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [ ] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [ ] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [ ] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##
