### PR TITLE
[RSPEED-1181, RSPEED-1184] Fix Life Cycle timeline sort by name

### DIFF
--- a/src/Components/Lifecycle/filteringUtils.ts
+++ b/src/Components/Lifecycle/filteringUtils.ts
@@ -10,8 +10,9 @@ export const RHEL_SYSTEMS_DROPDOWN_VALUE = 'Red Hat Enterprise Linux';
 export const filterChartDataByName = (data: Stream[] | SystemLifecycleChanges[], dropdownValue: string) => {
   if (dropdownValue === DEFAULT_DROPDOWN_VALUE) {
     return (data as Stream[]).sort((a: Stream, b: Stream) => {
-      const aName = `${a.name.toLowerCase()}`;
-      const bName = `${b.name.toLowerCase()}`;
+      // Updated to use display_name for consistency with filtering
+      const aName = `${a.display_name.toLowerCase()}`;
+      const bName = `${b.display_name.toLowerCase()}`;
       if (aName > bName) return -1;
       if (aName < bName) return 1;
       return 0;
@@ -19,8 +20,9 @@ export const filterChartDataByName = (data: Stream[] | SystemLifecycleChanges[],
   }
   if (dropdownValue === RHEL_8_STREAMS_DROPDOWN_VALUE) {
     return (data as Stream[]).sort((a: Stream, b: Stream) => {
-      const aName = `${a.name.toLowerCase()}`;
-      const bName = `${b.name.toLowerCase()}`;
+      // Updated to use display_name for consistency with filtering
+      const aName = `${a.display_name.toLowerCase()}`;
+      const bName = `${b.display_name.toLowerCase()}`;
       if (aName > bName) return -1;
       if (aName < bName) return 1;
       return 0;

--- a/src/Components/LifecycleTable/LifecycleTable.tsx
+++ b/src/Components/LifecycleTable/LifecycleTable.tsx
@@ -70,7 +70,7 @@ export const LifecycleTable: React.FunctionComponent<LifecycleTableProps> = ({
   };
 
   const type = checkDataType(data);
-  
+
   React.useEffect(() => {
     setActiveAppSortDirection(undefined);
     setActiveSystemSortDirection(undefined);
@@ -208,7 +208,7 @@ export const LifecycleTable: React.FunctionComponent<LifecycleTableProps> = ({
   const sortAppLifecycleData = (index?: number, direction?: string) => {
     // Create a copy of the data
     let sortedRepositories = [...(data as Stream[])];
-  
+
     if (typeof index !== 'undefined') {
       sortedRepositories = sortedRepositories.sort((a: Stream, b: Stream) => {
         const aValue = getAppSortableRowValues(a)[index];
@@ -216,7 +216,7 @@ export const LifecycleTable: React.FunctionComponent<LifecycleTableProps> = ({
         return sort(aValue, bValue, direction);
       });
     }
-  
+
     return sortedRepositories;
   };
 
@@ -260,7 +260,7 @@ export const LifecycleTable: React.FunctionComponent<LifecycleTableProps> = ({
   const sortSystemLifecycleData = (index?: number, direction?: string) => {
     // Create a copy of the data
     let sortedRepositories = [...(data as SystemLifecycleChanges[])];
-    
+
     if (typeof index !== 'undefined') {
       sortedRepositories = sortedRepositories.sort((a: SystemLifecycleChanges, b: SystemLifecycleChanges) => {
         const aValue = getSystemSortableRowValues(a)[index];

--- a/src/Components/LifecycleTable/LifecycleTable.tsx
+++ b/src/Components/LifecycleTable/LifecycleTable.tsx
@@ -70,7 +70,7 @@ export const LifecycleTable: React.FunctionComponent<LifecycleTableProps> = ({
   };
 
   const type = checkDataType(data);
-
+  
   React.useEffect(() => {
     setActiveAppSortDirection(undefined);
     setActiveSystemSortDirection(undefined);
@@ -80,9 +80,10 @@ export const LifecycleTable: React.FunctionComponent<LifecycleTableProps> = ({
     setPerPage(10);
     let sortedData;
     if (type === 'streams') {
-      sortedData = sortAppLifecycleData();
+      // Pass default index and direction for consistent initial sorting
+      sortedData = sortAppLifecycleData(0, 'asc');
     } else {
-      sortedData = sortSystemLifecycleData();
+      sortedData = sortSystemLifecycleData(0, 'asc');
     }
     setSortedRows(sortedData);
     setPaginatedRows(sortedData.slice(0, 10));
@@ -148,8 +149,8 @@ export const LifecycleTable: React.FunctionComponent<LifecycleTableProps> = ({
   };
 
   const getAppSortableRowValues = (repo: Stream): (string | number)[] => {
-    const { name, os_major, start_date, end_date, count } = repo;
-    return [name, os_major, start_date ?? 'Not available', end_date ?? 'Not available', count];
+    const { display_name, os_major, start_date, end_date, count } = repo;
+    return [display_name, os_major, start_date ?? 'Not available', end_date ?? 'Not available', count];
   };
 
   const getSystemSortParams = (columnIndex: number): ThProps['sort'] => ({
@@ -205,8 +206,9 @@ export const LifecycleTable: React.FunctionComponent<LifecycleTableProps> = ({
   };
 
   const sortAppLifecycleData = (index?: number, direction?: string) => {
-    let sortedRepositories = data as Stream[];
-
+    // Create a copy of the data
+    let sortedRepositories = [...(data as Stream[])];
+  
     if (typeof index !== 'undefined') {
       sortedRepositories = sortedRepositories.sort((a: Stream, b: Stream) => {
         const aValue = getAppSortableRowValues(a)[index];
@@ -214,7 +216,7 @@ export const LifecycleTable: React.FunctionComponent<LifecycleTableProps> = ({
         return sort(aValue, bValue, direction);
       });
     }
-
+  
     return sortedRepositories;
   };
 
@@ -256,7 +258,9 @@ export const LifecycleTable: React.FunctionComponent<LifecycleTableProps> = ({
   };
 
   const sortSystemLifecycleData = (index?: number, direction?: string) => {
-    let sortedRepositories = data as SystemLifecycleChanges[];
+    // Create a copy of the data
+    let sortedRepositories = [...(data as SystemLifecycleChanges[])];
+    
     if (typeof index !== 'undefined') {
       sortedRepositories = sortedRepositories.sort((a: SystemLifecycleChanges, b: SystemLifecycleChanges) => {
         const aValue = getSystemSortableRowValues(a)[index];


### PR DESCRIPTION
### Description
<!-- Must include 2-3 sentence summary of proposed changes -->
<!-- Must include links to impacted UI(s) or information regarding the impacted UI -->
<!-- Must include any relevant steps to reproduce (if not clear in tracked issue or story) -->
<!-- Must include RSPEED-XXX link (if proposed change involves tracked issue or story) -->
This PR fixes the issues with sorting in the Life Cycle table and chart. Main issue was that the new display_name field was not being used in the sorting. Also inverts the sorting for Systems to descending order and disables system sorting when in the All view.
Jira link:
[RSPEED-1181](https://issues.redhat.com/browse/RSPEED-1181)
[RSPEED-1184](https://issues.redhat.com/browse/RSPEED-1184)

---

### Screenshots
<!-- Before and after proposed changes is ideal -->
<!-- Any key UI permutations should be captured -->
<!-- Draw attention to the area of UI that has changed -->
#### Before:


#### After:


---

### Checklist ☑️
- [ ] PR only fixes one issue or story <!-- open new PR for others -->
- [ ] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [ ] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [ ] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [ ] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##
