### PR TITLE
[RSPEED-1371] Add numeric:true to localCompare sorting

### DIFF
--- a/src/Components/Lifecycle/filteringUtils.ts
+++ b/src/Components/Lifecycle/filteringUtils.ts
@@ -10,30 +10,19 @@ export const RHEL_SYSTEMS_DROPDOWN_VALUE = 'Red Hat Enterprise Linux';
 export const filterChartDataByName = (data: Stream[] | SystemLifecycleChanges[], dropdownValue: string) => {
   if (dropdownValue === DEFAULT_DROPDOWN_VALUE) {
     return (data as Stream[]).sort((a: Stream, b: Stream) => {
-      // Updated to use display_name for consistency with filtering
-      const aName = `${a.display_name.toLowerCase()}`;
-      const bName = `${b.display_name.toLowerCase()}`;
-      if (aName > bName) return -1;
-      if (aName < bName) return 1;
-      return 0;
+      // localeCompare with numeric: true handles version numbers correctly
+      return b.display_name.localeCompare(a.display_name, undefined, { numeric: true });
     });
   }
   if (dropdownValue === RHEL_8_STREAMS_DROPDOWN_VALUE) {
     return (data as Stream[]).sort((a: Stream, b: Stream) => {
-      // Updated to use display_name for consistency with filtering
-      const aName = `${a.display_name.toLowerCase()}`;
-      const bName = `${b.display_name.toLowerCase()}`;
-      if (aName > bName) return -1;
-      if (aName < bName) return 1;
-      return 0;
+      return b.display_name.localeCompare(a.display_name, undefined, { numeric: true });
     });
   }
   return (data as SystemLifecycleChanges[]).sort((a, b) => {
     const aName = getNewChartName(a.name, a.major, a.minor, a.lifecycle_type);
     const bName = getNewChartName(b.name, b.major, b.minor, b.lifecycle_type);
-    if (aName > bName) return -1;
-    if (aName < bName) return 1;
-    return 0;
+    return bName.localeCompare(aName, undefined, { numeric: true });
   });
 };
 

--- a/src/Components/Lifecycle/filteringUtils.ts
+++ b/src/Components/Lifecycle/filteringUtils.ts
@@ -86,26 +86,26 @@ export const filterChartDataByRetirementDate = (
 };
 
 export const filterChartDataByRelease = (data: Stream[] | SystemLifecycleChanges[], dropdownValue: string) => {
-    if (dropdownValue === DEFAULT_DROPDOWN_VALUE) {
-      return (data as Stream[]).sort((a: Stream, b: Stream) => {
-        if (a.os_major > b.os_major) return -1;
-        if (a.os_major < b.os_major) return 1;
-        // If os_major is equal, compare os_minor
-        if (a.os_minor > b.os_minor) return -1;
-        if (a.os_minor < b.os_minor) return 1;
-        return 0;
-      });
-    }
-    if (dropdownValue === RHEL_8_STREAMS_DROPDOWN_VALUE) {
-      return (data as Stream[]).sort((a: Stream, b: Stream) => {
-        if (a.os_major > b.os_major) return -1;
-        if (a.os_major < b.os_major) return 1;
-        // If os_major is equal, compare os_minor
-        if (a.os_minor > b.os_minor) return -1;
-        if (a.os_minor < b.os_minor) return 1;
-        return 0;
-      });
-    }
+  if (dropdownValue === DEFAULT_DROPDOWN_VALUE) {
+    return (data as Stream[]).sort((a: Stream, b: Stream) => {
+      if (a.os_major > b.os_major) return -1;
+      if (a.os_major < b.os_major) return 1;
+      // If os_major is equal, compare os_minor
+      if (a.os_minor > b.os_minor) return -1;
+      if (a.os_minor < b.os_minor) return 1;
+      return 0;
+    });
+  }
+  if (dropdownValue === RHEL_8_STREAMS_DROPDOWN_VALUE) {
+    return (data as Stream[]).sort((a: Stream, b: Stream) => {
+      if (a.os_major > b.os_major) return -1;
+      if (a.os_major < b.os_major) return 1;
+      // If os_major is equal, compare os_minor
+      if (a.os_minor > b.os_minor) return -1;
+      if (a.os_minor < b.os_minor) return 1;
+      return 0;
+    });
+  }
   // Using full RHEL name comparison instead of major and minor so we can also take into account the lifecycle type
   return (data as SystemLifecycleChanges[]).sort((a, b) => {
     return b.display_name.localeCompare(a.display_name, undefined, { numeric: true });

--- a/src/Components/Lifecycle/filteringUtils.ts
+++ b/src/Components/Lifecycle/filteringUtils.ts
@@ -99,26 +99,22 @@ export const filterChartDataByRetirementDate = (
   });
 };
 
-// Using display name comparison instead of major and minor so we can also take into account the lifecycle type
 export const filterChartDataByRelease = (data: Stream[] | SystemLifecycleChanges[], dropdownValue: string) => {
   if (dropdownValue === DEFAULT_DROPDOWN_VALUE) {
     return (data as Stream[]).sort((a: Stream, b: Stream) => {
-      const aName = `${a.display_name.toLowerCase()}`;
-      const bName = `${b.display_name.toLowerCase()}`;
-      if (aName > bName) return -1;
-      if (aName < bName) return 1;
+      if (a.os_major > b.os_major) return -1;
+      if (a.os_major < b.os_major) return 1;
       return 0;
     });
   }
   if (dropdownValue === RHEL_8_STREAMS_DROPDOWN_VALUE) {
     return (data as Stream[]).sort((a: Stream, b: Stream) => {
-      const aName = `${a.display_name.toLowerCase()}`;
-      const bName = `${b.display_name.toLowerCase()}`;
-      if (aName > bName) return -1;
-      if (aName < bName) return 1;
+      if (a.os_major > b.os_major) return -1;
+      if (a.os_major < b.os_major) return 1;
       return 0;
     });
   }
+  // Using full RHEL name comparison instead of major and minor so we can also take into account the lifecycle type
   return (data as SystemLifecycleChanges[]).sort((a, b) => {
     const aName = getNewChartName(a.name, a.major, a.minor, a.lifecycle_type);
     const bName = getNewChartName(b.name, b.major, b.minor, b.lifecycle_type);
@@ -127,7 +123,6 @@ export const filterChartDataByRelease = (data: Stream[] | SystemLifecycleChanges
     return 0;
   });
 };
-
 
 export const filterChartDataBySystems = (data: Stream[] | SystemLifecycleChanges[], dropdownValue: string) => {
   if (dropdownValue === DEFAULT_DROPDOWN_VALUE) {

--- a/src/Components/Lifecycle/filteringUtils.ts
+++ b/src/Components/Lifecycle/filteringUtils.ts
@@ -10,22 +10,12 @@ export const RHEL_SYSTEMS_DROPDOWN_VALUE = 'Red Hat Enterprise Linux';
 export const filterChartDataByName = (data: Stream[] | SystemLifecycleChanges[], dropdownValue: string) => {
   if (dropdownValue === DEFAULT_DROPDOWN_VALUE) {
     return (data as Stream[]).sort((a: Stream, b: Stream) => {
-      // Updated to use display_name for consistency with filtering
-      const aName = `${a.display_name.toLowerCase()}`;
-      const bName = `${b.display_name.toLowerCase()}`;
-      if (aName > bName) return -1;
-      if (aName < bName) return 1;
-      return 0;
+      return b.display_name.localeCompare(a.display_name, undefined, { numeric: true });
     });
   }
   if (dropdownValue === RHEL_8_STREAMS_DROPDOWN_VALUE) {
     return (data as Stream[]).sort((a: Stream, b: Stream) => {
-      // Updated to use display_name for consistency with filtering
-      const aName = `${a.display_name.toLowerCase()}`;
-      const bName = `${b.display_name.toLowerCase()}`;
-      if (aName > bName) return -1;
-      if (aName < bName) return 1;
-      return 0;
+      return b.display_name.localeCompare(a.display_name, undefined, { numeric: true });
     });
   }
   return (data as SystemLifecycleChanges[]).sort((a, b) => {
@@ -96,20 +86,26 @@ export const filterChartDataByRetirementDate = (
 };
 
 export const filterChartDataByRelease = (data: Stream[] | SystemLifecycleChanges[], dropdownValue: string) => {
-  if (dropdownValue === DEFAULT_DROPDOWN_VALUE) {
-    return (data as Stream[]).sort((a: Stream, b: Stream) => {
-      if (a.os_major > b.os_major) return -1;
-      if (a.os_major < b.os_major) return 1;
-      return 0;
-    });
-  }
-  if (dropdownValue === RHEL_8_STREAMS_DROPDOWN_VALUE) {
-    return (data as Stream[]).sort((a: Stream, b: Stream) => {
-      if (a.os_major > b.os_major) return -1;
-      if (a.os_major < b.os_major) return 1;
-      return 0;
-    });
-  }
+    if (dropdownValue === DEFAULT_DROPDOWN_VALUE) {
+      return (data as Stream[]).sort((a: Stream, b: Stream) => {
+        if (a.os_major > b.os_major) return -1;
+        if (a.os_major < b.os_major) return 1;
+        // If os_major is equal, compare os_minor
+        if (a.os_minor > b.os_minor) return -1;
+        if (a.os_minor < b.os_minor) return 1;
+        return 0;
+      });
+    }
+    if (dropdownValue === RHEL_8_STREAMS_DROPDOWN_VALUE) {
+      return (data as Stream[]).sort((a: Stream, b: Stream) => {
+        if (a.os_major > b.os_major) return -1;
+        if (a.os_major < b.os_major) return 1;
+        // If os_major is equal, compare os_minor
+        if (a.os_minor > b.os_minor) return -1;
+        if (a.os_minor < b.os_minor) return 1;
+        return 0;
+      });
+    }
   // Using full RHEL name comparison instead of major and minor so we can also take into account the lifecycle type
   return (data as SystemLifecycleChanges[]).sort((a, b) => {
     return b.display_name.localeCompare(a.display_name, undefined, { numeric: true });

--- a/src/Components/Lifecycle/filteringUtils.ts
+++ b/src/Components/Lifecycle/filteringUtils.ts
@@ -29,11 +29,7 @@ export const filterChartDataByName = (data: Stream[] | SystemLifecycleChanges[],
     });
   }
   return (data as SystemLifecycleChanges[]).sort((a, b) => {
-    const aName = getNewChartName(a.name, a.major, a.minor, a.lifecycle_type);
-    const bName = getNewChartName(b.name, b.major, b.minor, b.lifecycle_type);
-    if (aName > bName) return -1;
-    if (aName < bName) return 1;
-    return 0;
+    return b.display_name.localeCompare(a.display_name, undefined, { numeric: true });
   });
 };
 
@@ -116,11 +112,7 @@ export const filterChartDataByRelease = (data: Stream[] | SystemLifecycleChanges
   }
   // Using full RHEL name comparison instead of major and minor so we can also take into account the lifecycle type
   return (data as SystemLifecycleChanges[]).sort((a, b) => {
-    const aName = getNewChartName(a.name, a.major, a.minor, a.lifecycle_type);
-    const bName = getNewChartName(b.name, b.major, b.minor, b.lifecycle_type);
-    if (aName > bName) return -1;
-    if (aName < bName) return 1;
-    return 0;
+    return b.display_name.localeCompare(a.display_name, undefined, { numeric: true });
   });
 };
 

--- a/src/Components/Lifecycle/filteringUtils.ts
+++ b/src/Components/Lifecycle/filteringUtils.ts
@@ -10,19 +10,30 @@ export const RHEL_SYSTEMS_DROPDOWN_VALUE = 'Red Hat Enterprise Linux';
 export const filterChartDataByName = (data: Stream[] | SystemLifecycleChanges[], dropdownValue: string) => {
   if (dropdownValue === DEFAULT_DROPDOWN_VALUE) {
     return (data as Stream[]).sort((a: Stream, b: Stream) => {
-      // localeCompare with numeric: true handles version numbers correctly
-      return b.display_name.localeCompare(a.display_name, undefined, { numeric: true });
+      // Updated to use display_name for consistency with filtering
+      const aName = `${a.display_name.toLowerCase()}`;
+      const bName = `${b.display_name.toLowerCase()}`;
+      if (aName > bName) return -1;
+      if (aName < bName) return 1;
+      return 0;
     });
   }
   if (dropdownValue === RHEL_8_STREAMS_DROPDOWN_VALUE) {
     return (data as Stream[]).sort((a: Stream, b: Stream) => {
-      return b.display_name.localeCompare(a.display_name, undefined, { numeric: true });
+      // Updated to use display_name for consistency with filtering
+      const aName = `${a.display_name.toLowerCase()}`;
+      const bName = `${b.display_name.toLowerCase()}`;
+      if (aName > bName) return -1;
+      if (aName < bName) return 1;
+      return 0;
     });
   }
   return (data as SystemLifecycleChanges[]).sort((a, b) => {
     const aName = getNewChartName(a.name, a.major, a.minor, a.lifecycle_type);
     const bName = getNewChartName(b.name, b.major, b.minor, b.lifecycle_type);
-    return bName.localeCompare(aName, undefined, { numeric: true });
+    if (aName > bName) return -1;
+    if (aName < bName) return 1;
+    return 0;
   });
 };
 
@@ -88,29 +99,35 @@ export const filterChartDataByRetirementDate = (
   });
 };
 
+// Using display name comparison instead of major and minor so we can also take into account the lifecycle type
 export const filterChartDataByRelease = (data: Stream[] | SystemLifecycleChanges[], dropdownValue: string) => {
   if (dropdownValue === DEFAULT_DROPDOWN_VALUE) {
     return (data as Stream[]).sort((a: Stream, b: Stream) => {
-      if (a.os_major > b.os_major) return -1;
-      if (a.os_major < b.os_major) return 1;
+      const aName = `${a.display_name.toLowerCase()}`;
+      const bName = `${b.display_name.toLowerCase()}`;
+      if (aName > bName) return -1;
+      if (aName < bName) return 1;
       return 0;
     });
   }
   if (dropdownValue === RHEL_8_STREAMS_DROPDOWN_VALUE) {
     return (data as Stream[]).sort((a: Stream, b: Stream) => {
-      if (a.os_major > b.os_major) return -1;
-      if (a.os_major < b.os_major) return 1;
+      const aName = `${a.display_name.toLowerCase()}`;
+      const bName = `${b.display_name.toLowerCase()}`;
+      if (aName > bName) return -1;
+      if (aName < bName) return 1;
       return 0;
     });
   }
   return (data as SystemLifecycleChanges[]).sort((a, b) => {
-    const aVer = `${a.major}.${a.minor}`;
-    const bVer = `${b.major}.${b.minor}`;
-    if (aVer > bVer) return -1;
-    if (aVer < bVer) return 1;
+    const aName = getNewChartName(a.name, a.major, a.minor, a.lifecycle_type);
+    const bName = getNewChartName(b.name, b.major, b.minor, b.lifecycle_type);
+    if (aName > bName) return -1;
+    if (aName < bName) return 1;
     return 0;
   });
 };
+
 
 export const filterChartDataBySystems = (data: Stream[] | SystemLifecycleChanges[], dropdownValue: string) => {
   if (dropdownValue === DEFAULT_DROPDOWN_VALUE) {

--- a/src/Components/LifecycleTable/LifecycleTable.tsx
+++ b/src/Components/LifecycleTable/LifecycleTable.tsx
@@ -224,9 +224,9 @@ export const LifecycleTable: React.FunctionComponent<LifecycleTableProps> = ({
     } else {
       // String sort
       if (direction === 'asc') {
-        return (aValue as string).localeCompare(bValue as string);
+        return (aValue as string).localeCompare(bValue as string, undefined, { numeric: true });
       }
-      return (bValue as string).localeCompare(aValue as string);
+      return (bValue as string).localeCompare(aValue as string, undefined, { numeric: true });
     }
   };
 


### PR DESCRIPTION
### Description
<!-- Must include 2-3 sentence summary of proposed changes -->
<!-- Must include links to impacted UI(s) or information regarding the impacted UI -->
<!-- Must include any relevant steps to reproduce (if not clear in tracked issue or story) -->
<!-- Must include RSPEED-XXX link (if proposed change involves tracked issue or story) -->
This PR adds numeric:true to our localCompare sorting components for RHEL version names. Adding this flag ensures that strings with numbers are sorted properly. 
Jira link:
[RSPEED-1371](https://issues.redhat.com/browse/RSPEED-1371)

---

### Screenshots
<!-- Before and after proposed changes is ideal -->
<!-- Any key UI permutations should be captured -->
<!-- Draw attention to the area of UI that has changed -->
#### Before:
![image](https://github.com/user-attachments/assets/2ff05b91-fd1c-423c-8a31-fa66c9d5483b)


#### After:
![image](https://github.com/user-attachments/assets/766143a3-dbfb-40f7-ae0f-d39de07b0667)


---

### Checklist ☑️
- [ ] PR only fixes one issue or story <!-- open new PR for others -->
- [ ] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [ ] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [ ] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [ ] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##
