### PR TITLE
Disable relevant view when there is no relevant data

### DIFF
--- a/src/Components/Upcoming/Upcoming.tsx
+++ b/src/Components/Upcoming/Upcoming.tsx
@@ -68,6 +68,7 @@ const UpcomingTab: React.FC<React.PropsWithChildren> = () => {
   const [currentNameFilter, setCurrentNameFilters] = React.useState('');
   const [currentReleaseFilters, setCurrentReleaseFilters] = React.useState<string[]>([]);
   const [error, setError] = React.useState<ErrorObject>();
+  const [noAllDataAvailable, setNoAllDataAvailable] = useState<boolean>(false);
   const [noDataAvailable, setNoDataAvailable] = useState<boolean>(false);
   const [searchParams, setSearchParams] = useSearchParams();
   const [filtersForURL, setFiltersForURL] = React.useState<Filter>(DEFAULT_FILTERS);
@@ -120,6 +121,11 @@ const UpcomingTab: React.FC<React.PropsWithChildren> = () => {
 
   // Handle view filter changes
   const handleViewFilterChange = (filter: string) => {
+    // Don't allow switching to relevant if no relevant data available
+    if (filter === 'relevant' && noDataAvailable) {
+      return;
+    }
+
     setSelectedViewFilter(filter);
     const newFilters = structuredClone(filtersForURL);
     newFilters['viewFilter'] = filter;
@@ -141,6 +147,8 @@ const UpcomingTab: React.FC<React.PropsWithChildren> = () => {
         // Use cached data
         setUpcomingChanges(relevantUpcomingChangesData);
         processData(relevantUpcomingChangesData);
+        // Set noDataAvailable based on cached data
+        setNoDataAvailable(relevantUpcomingChangesData.length === 0);
       } else {
         // Fetch data
         fetchData(filter);
@@ -148,84 +156,145 @@ const UpcomingTab: React.FC<React.PropsWithChildren> = () => {
     }
   };
 
+  useEffect(() => {
+    // If we've loaded relevant data and it's empty, and all data is available and not empty
+    // then automatically switch to "all" view regardless of current view
+    if (dataFetchStatus.relevant && 
+        relevantUpcomingChangesData.length === 0 && 
+        dataFetchStatus.all && 
+        allUpcomingChangesData.length > 0 && 
+        selectedViewFilter === 'relevant') {
+      console.log('Auto-switching to "all" view due to empty relevant data');
+      
+      // Force the view to "all"
+      setSelectedViewFilter('all');
+      
+      // Update URL and filters
+      const newFilters = structuredClone(filtersForURL);
+      newFilters['viewFilter'] = 'all';
+      setFiltersForURL(newFilters);
+      setSearchParams(buildURL(newFilters));
+      
+      // Use the all data
+      setUpcomingChanges(allUpcomingChangesData);
+      processData(allUpcomingChangesData);
+    }
+  }, [dataFetchStatus.relevant, dataFetchStatus.all, relevantUpcomingChangesData.length, allUpcomingChangesData.length]);
+
   const fetchData = async (viewFilter?: string) => {
     setIsLoading(true);
-    setNoDataAvailable(false);
+    setNoAllDataAvailable(false);
+    setNoDataAvailable(false); // Reset noDataAvailable when starting to fetch
     const currentViewFilter = viewFilter || selectedViewFilter;
-
+  
     try {
       // Choose API based on view filter
       if (currentViewFilter === 'all') {
         const response = await getAllUpcomingChanges();
         let upcomingChangesParagraphs: UpcomingChanges[] = response && response.data ? response.data : [];
-
+  
         // Check if ALL data source is empty - only then show no data state
         if (upcomingChangesParagraphs.length === 0) {
-          setNoDataAvailable(true);
+          setNoAllDataAvailable(true);
           setIsLoading(false);
           return;
         }
-
+  
         // Process the data to capitalize type values
         upcomingChangesParagraphs = upcomingChangesParagraphs.map((item) => ({
           ...item,
           type: capitalizeFirstLetter(item.type),
         }));
-
+  
         // Store the all data in state
         setAllUpcomingChangesData(upcomingChangesParagraphs);
         setDataFetchStatus((prev) => ({ ...prev, all: true }));
         setUpcomingChanges(upcomingChangesParagraphs);
         processData(upcomingChangesParagraphs);
+        
+        // Check if relevant data is already fetched
+        if (dataFetchStatus.relevant) {
+          // Use cached data to determine if relevant data is empty
+          setNoDataAvailable(relevantUpcomingChangesData.length === 0);
+        } else {
+          // Fetch relevant data to check if it's empty
+          try {
+            const relevantResponse = await getRelevantUpcomingChanges();
+            let relevantData: UpcomingChanges[] = relevantResponse && relevantResponse.data ? relevantResponse.data : [];
+            
+            // Process the relevant data
+            relevantData = relevantData.map((item) => ({
+              ...item,
+              type: capitalizeFirstLetter(item.type),
+            }));
+            
+            // Store the relevant data
+            setRelevantUpcomingChangesData(relevantData);
+            setDataFetchStatus((prev) => ({ ...prev, relevant: true }));
+            
+            // Set noDataAvailable based on whether relevant data exists
+            setNoDataAvailable(relevantData.length === 0);
+          } catch (error) {
+            console.error('Error fetching relevant changes:', error);
+            // Don't set error state here as we already have all data
+          }
+        }
       } else {
         // For relevant view, first check if we need to fetch "all" data to verify emptiness
         if (!dataFetchStatus.all) {
           // We need to check if "all" data is empty
           const allResponse = await getAllUpcomingChanges();
           const allData: UpcomingChanges[] = allResponse && allResponse.data ? allResponse.data : [];
-
+  
           // Store the all data in state
           const processedAllData = allData.map((item) => ({
             ...item,
             type: capitalizeFirstLetter(item.type),
           }));
-
+  
           setAllUpcomingChangesData(processedAllData);
           setDataFetchStatus((prev) => ({ ...prev, all: true }));
-
+  
           // If all data is empty, show no data state regardless of current view
           if (allData.length === 0) {
-            setNoDataAvailable(true);
+            setNoAllDataAvailable(true);
             setIsLoading(false);
             return;
           }
         } else if (allUpcomingChangesData.length === 0) {
           // We already know "all" data is empty
-          setNoDataAvailable(true);
+          setNoAllDataAvailable(true);
           setIsLoading(false);
           return;
         }
-
+  
         // Now fetch relevant data
         const response = await getRelevantUpcomingChanges();
         let upcomingChangesParagraphs: UpcomingChanges[] = response && response.data ? response.data : [];
-
+  
+        // Check if relevant data is empty
+        if (upcomingChangesParagraphs.length === 0) {
+          setNoDataAvailable(true);
+        } else {
+          setNoDataAvailable(false);
+        }
+  
         // Process the data to capitalize type values
         upcomingChangesParagraphs = upcomingChangesParagraphs.map((item) => ({
           ...item,
           type: capitalizeFirstLetter(item.type),
         }));
-
+  
         // Store the relevant data in state
         setRelevantUpcomingChangesData(upcomingChangesParagraphs);
         setDataFetchStatus((prev) => ({ ...prev, relevant: true }));
         setUpcomingChanges(upcomingChangesParagraphs);
         processData(upcomingChangesParagraphs);
       }
-
+  
       // Apply URL parameters
       const newFilters = structuredClone(filtersForURL);
-
+  
       // Apply URL parameters if this is the initial load
       if (nameParam) {
         const name = decodeURIComponent(nameParam);
@@ -247,9 +316,9 @@ const UpcomingTab: React.FC<React.PropsWithChildren> = () => {
         setCurrentDateFilter(date);
         newFilters['date'] = date;
       }
-
+  
       // Include view filter in URL
-      newFilters['viewFilter'] = currentViewFilter;
+      newFilters['viewFilter'] = selectedViewFilter; // Use the potentially updated view filter
       setFiltersForURL(newFilters);
       setIsLoading(false);
     } catch (error: any) {
@@ -281,19 +350,35 @@ const UpcomingTab: React.FC<React.PropsWithChildren> = () => {
     setCurrentDateFilter('');
     setCurrentNameFilters('');
     setCurrentReleaseFilters([]);
-    setSelectedViewFilter('relevant');
+
+    // Don't reset to relevant if no relevant data available
+    if (!noDataAvailable) {
+      setSelectedViewFilter('relevant');
+    }
 
     // Use cached relevant data if available
     if (dataFetchStatus.relevant) {
-      setUpcomingChanges(relevantUpcomingChangesData);
-      setVisibleData(relevantUpcomingChangesData);
+      if (relevantUpcomingChangesData.length === 0 && allUpcomingChangesData.length > 0) {
+        // If relevant data is empty but all data exists, use all data
+        setUpcomingChanges(allUpcomingChangesData);
+        setVisibleData(allUpcomingChangesData);
+        setSelectedViewFilter('all');
+      } else {
+        setUpcomingChanges(relevantUpcomingChangesData);
+        setVisibleData(relevantUpcomingChangesData);
+      }
+      // Update noDataAvailable based on cached relevant data
+      setNoDataAvailable(relevantUpcomingChangesData.length === 0);
     } else {
       setVisibleData(upcomingChanges);
-      fetchData('relevant');
+      fetchData(noDataAvailable ? 'all' : 'relevant');
     }
 
-    setFiltersForURL(DEFAULT_FILTERS);
-    setSearchParams(buildURL(DEFAULT_FILTERS));
+    // Update filters for URL
+    const newFilters : any = structuredClone(DEFAULT_FILTERS);
+    newFilters['viewFilter'] = noDataAvailable ? 'all' : 'relevant';
+    setFiltersForURL(newFilters);
+    setSearchParams(buildURL(newFilters));
   };
 
   const setTypeParam = (type: Set<string>) => {
@@ -339,8 +424,8 @@ const UpcomingTab: React.FC<React.PropsWithChildren> = () => {
     return <ErrorState errorTitle="Failed to load data" errorDescription={String(error.message)} />;
   }
 
-  // New error state for when no data is available
-  if (noDataAvailable) {
+  // New error state for when no all data is available
+  if (noAllDataAvailable) {
     return (
       <Bullseye>
         <EmptyState variant={EmptyStateVariant.lg}>
@@ -447,6 +532,7 @@ const UpcomingTab: React.FC<React.PropsWithChildren> = () => {
           setFiltersForURL={updateChildFilters}
           selectedViewFilter={selectedViewFilter}
           handleViewFilterChange={handleViewFilterChange}
+          noDataAvailable={noDataAvailable} 
         />
       </StackItem>
     </Stack>

--- a/src/Components/Upcoming/Upcoming.tsx
+++ b/src/Components/Upcoming/Upcoming.tsx
@@ -159,59 +159,66 @@ const UpcomingTab: React.FC<React.PropsWithChildren> = () => {
   useEffect(() => {
     // If we've loaded relevant data and it's empty, and all data is available and not empty
     // then automatically switch to "all" view regardless of current view
-    if (dataFetchStatus.relevant && 
-        relevantUpcomingChangesData.length === 0 && 
-        dataFetchStatus.all && 
-        allUpcomingChangesData.length > 0 && 
-        selectedViewFilter === 'relevant') {
+    if (
+      dataFetchStatus.relevant &&
+      relevantUpcomingChangesData.length === 0 &&
+      dataFetchStatus.all &&
+      allUpcomingChangesData.length > 0 &&
+      selectedViewFilter === 'relevant'
+    ) {
       console.log('Auto-switching to "all" view due to empty relevant data');
-      
+
       // Force the view to "all"
       setSelectedViewFilter('all');
-      
+
       // Update URL and filters
       const newFilters = structuredClone(filtersForURL);
       newFilters['viewFilter'] = 'all';
       setFiltersForURL(newFilters);
       setSearchParams(buildURL(newFilters));
-      
+
       // Use the all data
       setUpcomingChanges(allUpcomingChangesData);
       processData(allUpcomingChangesData);
     }
-  }, [dataFetchStatus.relevant, dataFetchStatus.all, relevantUpcomingChangesData.length, allUpcomingChangesData.length]);
+  }, [
+    dataFetchStatus.relevant,
+    dataFetchStatus.all,
+    relevantUpcomingChangesData.length,
+    allUpcomingChangesData.length,
+  ]);
 
   const fetchData = async (viewFilter?: string) => {
     setIsLoading(true);
     setNoAllDataAvailable(false);
     setNoDataAvailable(false); // Reset noDataAvailable when starting to fetch
     const currentViewFilter = viewFilter || selectedViewFilter;
-  
+
     try {
       // Choose API based on view filter
       if (currentViewFilter === 'all') {
         const response = await getAllUpcomingChanges();
         let upcomingChangesParagraphs: UpcomingChanges[] = response && response.data ? response.data : [];
-  
+
         // Check if ALL data source is empty - only then show no data state
         if (upcomingChangesParagraphs.length === 0) {
           setNoAllDataAvailable(true);
           setIsLoading(false);
           return;
         }
-  
+
         // Process the data to capitalize type values
         upcomingChangesParagraphs = upcomingChangesParagraphs.map((item) => ({
           ...item,
           type: capitalizeFirstLetter(item.type),
         }));
-  
+
         // Store the all data in state
         setAllUpcomingChangesData(upcomingChangesParagraphs);
         setDataFetchStatus((prev) => ({ ...prev, all: true }));
         setUpcomingChanges(upcomingChangesParagraphs);
         processData(upcomingChangesParagraphs);
-        
+
         // Check if relevant data is already fetched
         if (dataFetchStatus.relevant) {
           // Use cached data to determine if relevant data is empty
@@ -220,18 +227,19 @@ const UpcomingTab: React.FC<React.PropsWithChildren> = () => {
           // Fetch relevant data to check if it's empty
           try {
             const relevantResponse = await getRelevantUpcomingChanges();
-            let relevantData: UpcomingChanges[] = relevantResponse && relevantResponse.data ? relevantResponse.data : [];
-            
+            let relevantData: UpcomingChanges[] =
+              relevantResponse && relevantResponse.data ? relevantResponse.data : [];
+
             // Process the relevant data
             relevantData = relevantData.map((item) => ({
               ...item,
               type: capitalizeFirstLetter(item.type),
             }));
-            
+
             // Store the relevant data
             setRelevantUpcomingChangesData(relevantData);
             setDataFetchStatus((prev) => ({ ...prev, relevant: true }));
-            
+
             // Set noDataAvailable based on whether relevant data exists
             setNoDataAvailable(relevantData.length === 0);
           } catch (error) {
@@ -245,16 +253,16 @@ const UpcomingTab: React.FC<React.PropsWithChildren> = () => {
           // We need to check if "all" data is empty
           const allResponse = await getAllUpcomingChanges();
           const allData: UpcomingChanges[] = allResponse && allResponse.data ? allResponse.data : [];
-  
+
           // Store the all data in state
           const processedAllData = allData.map((item) => ({
             ...item,
             type: capitalizeFirstLetter(item.type),
           }));
-  
+
           setAllUpcomingChangesData(processedAllData);
           setDataFetchStatus((prev) => ({ ...prev, all: true }));
-  
+
           // If all data is empty, show no data state regardless of current view
           if (allData.length === 0) {
             setNoAllDataAvailable(true);
@@ -267,34 +275,34 @@ const UpcomingTab: React.FC<React.PropsWithChildren> = () => {
           setIsLoading(false);
           return;
         }
-  
+
         // Now fetch relevant data
         const response = await getRelevantUpcomingChanges();
         let upcomingChangesParagraphs: UpcomingChanges[] = response && response.data ? response.data : [];
-  
+
         // Check if relevant data is empty
         if (upcomingChangesParagraphs.length === 0) {
           setNoDataAvailable(true);
         } else {
           setNoDataAvailable(false);
         }
-  
+
         // Process the data to capitalize type values
         upcomingChangesParagraphs = upcomingChangesParagraphs.map((item) => ({
           ...item,
           type: capitalizeFirstLetter(item.type),
         }));
-  
+
         // Store the relevant data in state
         setRelevantUpcomingChangesData(upcomingChangesParagraphs);
         setDataFetchStatus((prev) => ({ ...prev, relevant: true }));
         setUpcomingChanges(upcomingChangesParagraphs);
         processData(upcomingChangesParagraphs);
       }
-  
+
       // Apply URL parameters
       const newFilters = structuredClone(filtersForURL);
-  
+
       // Apply URL parameters if this is the initial load
       if (nameParam) {
         const name = decodeURIComponent(nameParam);
@@ -316,7 +324,7 @@ const UpcomingTab: React.FC<React.PropsWithChildren> = () => {
         setCurrentDateFilter(date);
         newFilters['date'] = date;
       }
-  
+
       // Include view filter in URL
       newFilters['viewFilter'] = selectedViewFilter; // Use the potentially updated view filter
       setFiltersForURL(newFilters);
@@ -375,7 +383,7 @@ const UpcomingTab: React.FC<React.PropsWithChildren> = () => {
     }
 
     // Update filters for URL
-    const newFilters : any = structuredClone(DEFAULT_FILTERS);
+    const newFilters: any = structuredClone(DEFAULT_FILTERS);
     newFilters['viewFilter'] = noDataAvailable ? 'all' : 'relevant';
     setFiltersForURL(newFilters);
     setSearchParams(buildURL(newFilters));
@@ -532,7 +540,7 @@ const UpcomingTab: React.FC<React.PropsWithChildren> = () => {
           setFiltersForURL={updateChildFilters}
           selectedViewFilter={selectedViewFilter}
           handleViewFilterChange={handleViewFilterChange}
-          noDataAvailable={noDataAvailable} 
+          noDataAvailable={noDataAvailable}
         />
       </StackItem>
     </Stack>

--- a/src/Components/UpcomingTable/UpcomingTable.tsx
+++ b/src/Components/UpcomingTable/UpcomingTable.tsx
@@ -46,6 +46,7 @@ interface UpcomingTableProps {
   setFiltersForURL: (filters: Filter) => void;
   selectedViewFilter: string;
   handleViewFilterChange: (filter: string) => void;
+  noDataAvailable?: boolean;
 }
 
 export const UpcomingTable: React.FunctionComponent<UpcomingTableProps> = ({
@@ -60,6 +61,7 @@ export const UpcomingTable: React.FunctionComponent<UpcomingTableProps> = ({
   setFiltersForURL,
   selectedViewFilter,
   handleViewFilterChange,
+  noDataAvailable = false, // Default to false if not provided
 }) => {
   const [searchValue, setSearchValue] = useState(initialNameFilter ?? '');
   const [typeSelections, setTypeSelections] = useState<Set<string>>(initialTypeFilters);
@@ -315,6 +317,7 @@ export const UpcomingTable: React.FunctionComponent<UpcomingTableProps> = ({
         setFiltersForURL={setFiltersForURL}
         selectedViewFilter={selectedViewFilter}
         handleViewFilterChange={handleViewFilterChange}
+        noDataAvailable={noDataAvailable}
       />
       <Table aria-label="Upcoming changes, deprecations, and additions to your system" variant="compact">
         <Thead>

--- a/src/Components/UpcomingTable/UpcomingTableFilters.tsx
+++ b/src/Components/UpcomingTable/UpcomingTableFilters.tsx
@@ -426,10 +426,7 @@ export const UpcomingTableFilters: React.FunctionComponent<UpcomingTableFiltersP
               <Form>
                 <FormGroup className="drf-upcoming__filter-formgroup" label="View" fieldId="view-filter">
                   <ToggleGroup aria-label="Whether only relevant or all items are displayed">
-                    <Tooltip
-                      content={getTooltipContent()}
-                      trigger={noDataAvailable ? 'mouseenter' : 'manual'}
-                    >
+                    <Tooltip content={getTooltipContent()} trigger={noDataAvailable ? 'mouseenter' : 'manual'}>
                       <ToggleGroupItem
                         text="Relevant only"
                         buttonId="relevant"

--- a/src/Components/UpcomingTable/UpcomingTableFilters.tsx
+++ b/src/Components/UpcomingTable/UpcomingTableFilters.tsx
@@ -18,6 +18,7 @@ import {
   ToolbarGroup,
   ToolbarItem,
   ToolbarToggleGroup,
+  Tooltip,
 } from '@patternfly/react-core';
 import FilterIcon from '@patternfly/react-icons/dist/esm/icons/filter-icon';
 import './upcoming-table.scss';
@@ -64,6 +65,7 @@ interface UpcomingTableFiltersProps {
   setFiltersForURL: (filters: Filter) => void;
   selectedViewFilter: string;
   handleViewFilterChange: (filter: string) => void;
+  noDataAvailable?: boolean; // Add noDataAvailable prop with optional flag
 }
 
 export const UpcomingTableFilters: React.FunctionComponent<UpcomingTableFiltersProps> = ({
@@ -89,6 +91,7 @@ export const UpcomingTableFilters: React.FunctionComponent<UpcomingTableFiltersP
   setFiltersForURL,
   selectedViewFilter,
   handleViewFilterChange,
+  noDataAvailable = false, // Default to false if not provided
 }) => {
   const [isReleaseMenuOpen, setIsReleaseMenuOpen] = useState<boolean>(false);
   const [isDateMenuOpen, setIsDateMenuOpen] = useState<boolean>(false);
@@ -114,6 +117,11 @@ export const UpcomingTableFilters: React.FunctionComponent<UpcomingTableFiltersP
   const handleItemClick = (event: React.MouseEvent<any> | React.KeyboardEvent | MouseEvent) => {
     const id = event.currentTarget.id;
     handleViewFilterChange(id);
+  };
+
+  // Helper function to get tooltip content for relevant only view
+  const getTooltipContent = () => {
+    return 'Add systems to Inventory to view only upcoming features relevant to your organization.';
   };
 
   const onReleaseToggleClick = (ev: React.MouseEvent) => {
@@ -418,12 +426,18 @@ export const UpcomingTableFilters: React.FunctionComponent<UpcomingTableFiltersP
               <Form>
                 <FormGroup className="drf-upcoming__filter-formgroup" label="View" fieldId="view-filter">
                   <ToggleGroup aria-label="Whether only relevant or all items are displayed">
-                    <ToggleGroupItem
-                      text="Relevant only"
-                      buttonId="relevant"
-                      isSelected={selectedViewFilter === 'relevant'}
-                      onChange={handleItemClick}
-                    />
+                    <Tooltip
+                      content={getTooltipContent()}
+                      trigger={noDataAvailable ? 'mouseenter' : 'manual'}
+                    >
+                      <ToggleGroupItem
+                        text="Relevant only"
+                        buttonId="relevant"
+                        isSelected={selectedViewFilter === 'relevant'}
+                        isDisabled={noDataAvailable}
+                        onChange={handleItemClick}
+                      />
+                    </Tooltip>
                     <ToggleGroupItem
                       text="All"
                       buttonId="all"


### PR DESCRIPTION
### Description
<!-- Must include 2-3 sentence summary of proposed changes -->
<!-- Must include links to impacted UI(s) or information regarding the impacted UI -->
<!-- Must include any relevant steps to reproduce (if not clear in tracked issue or story) -->
<!-- Must include RSPEED-XXX link (if proposed change involves tracked issue or story) -->
This PR disables the relevant view in Roadmap when there is no data. Adds a tooltip to the relevant only view describing why it's disabled. Automatically switches to the All view if there is no relevant data. 
Jira link:
[RSPEED-XXX](https://issues.redhat.com/browse/RSPEED-XXX)

---

### Screenshots
<!-- Before and after proposed changes is ideal -->
<!-- Any key UI permutations should be captured -->
<!-- Draw attention to the area of UI that has changed -->
#### Before:


#### After:


---

### Checklist ☑️
- [ ] PR only fixes one issue or story <!-- open new PR for others -->
- [ ] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [ ] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [ ] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [ ] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##
