### PR TITLE
[RSPEED-1228] Completely remove chart items when hidden from the legend

### DIFF
--- a/src/Components/LifecycleChart/LifecycleChart.tsx
+++ b/src/Components/LifecycleChart/LifecycleChart.tsx
@@ -46,6 +46,10 @@ const LifecycleChart: React.FC<LifecycleChartProps> = ({ lifecycleData, viewFilt
   const [showDateTooltip, setShowDateTooltip] = React.useState<boolean>(false);
   const [mousePosition, setMousePosition] = React.useState({ x: 0, y: 0 });
 
+  // Hidden series state with forced re-render counter
+  const [hiddenSeries, setHiddenSeries] = React.useState(new Set());
+  const [renderKey, setRenderKey] = React.useState(0);
+
   //check data type and contruct a chart array
   const checkDataType = (lifecycleData: Stream[] | SystemLifecycleChanges[]) => {
     if (!lifecycleData || lifecycleData.length === 0) {
@@ -60,7 +64,6 @@ const LifecycleChart: React.FC<LifecycleChartProps> = ({ lifecycleData, viewFilt
   const dataType = checkDataType(lifecycleData);
   const updatedLifecycleData: ChartDataObject[][] = [];
   const years: { [key: string]: Date } = {};
-  const [hiddenSeries, setHiddenSeries] = React.useState(new Set());
 
   const formatChartData = (
     name: string,
@@ -226,10 +229,56 @@ const LifecycleChart: React.FC<LifecycleChartProps> = ({ lifecycleData, viewFilt
     }));
 
   const handleLegendClick = (props: { index: number }) => {
-    if (!hiddenSeries.delete(props.index)) {
-      hiddenSeries.add(props.index);
-    }
-    setHiddenSeries(new Set(hiddenSeries));
+    setHiddenSeries((prevHiddenSeries) => {
+      const newHiddenSeries = new Set(prevHiddenSeries);
+
+      // Get the count of series that have actual data
+      const totalVisibleSeries = legendNames.filter((s) => s.datapoints.length > 0).length;
+
+      // Convert Set to Array with proper typing
+      const hiddenIndices = Array.from(prevHiddenSeries) as number[];
+      const currentlyHiddenCount = hiddenIndices.filter((index: number) => {
+        return (
+          typeof index === 'number' &&
+          index >= 0 &&
+          index < legendNames.length &&
+          legendNames[index] &&
+          legendNames[index].datapoints.length > 0
+        );
+      }).length;
+
+      const isCurrentlyHidden = newHiddenSeries.has(props.index);
+
+      // If we're trying to hide the last visible series, don't allow it
+      if (!isCurrentlyHidden && currentlyHiddenCount >= totalVisibleSeries - 1) {
+        // Optionally show a message or just ignore the click
+        console.log('Cannot hide all series - at least one must remain visible');
+        return prevHiddenSeries; // Return unchanged state
+      }
+
+      // If we're trying to show a series when all are hidden, show this one and clear others
+      if (isCurrentlyHidden && currentlyHiddenCount === totalVisibleSeries) {
+        // Clear all hidden series to show everything
+        return new Set<number>();
+      }
+
+      // Normal toggle behavior
+      if (isCurrentlyHidden) {
+        newHiddenSeries.delete(props.index);
+      } else {
+        newHiddenSeries.add(props.index);
+      }
+
+      return newHiddenSeries;
+    });
+
+    // Force a re-render by updating the render key
+    setRenderKey((prev) => prev + 1);
+
+    // Clear any active tooltips when legend is clicked
+    setShowTooltip(false);
+    setShowDateTooltip(false);
+    setTooltipData(null);
   };
 
   const formatDate = (date: Date) => {
@@ -254,10 +303,20 @@ const LifecycleChart: React.FC<LifecycleChartProps> = ({ lifecycleData, viewFilt
     }
   };
 
-  const fetchTicks = () => {
-    return updatedLifecycleData.map((data) => {
-      return data[0].x;
+  // Get only the visible ticks based on hidden series
+  const getVisibleTicks = () => {
+    const visibleNames = new Set<string>();
+
+    legendNames.forEach((series, index) => {
+      if (!hiddenSeries.has(index)) {
+        series.datapoints.forEach((datapoint) => {
+          visibleNames.add(datapoint.x);
+        });
+      }
     });
+
+    // Maintain the original order from updatedLifecycleData
+    return updatedLifecycleData.map((data) => data[0].x).filter((name) => visibleNames.has(name));
   };
 
   const isHidden = (index: number) => hiddenSeries.has(index);
@@ -391,7 +450,6 @@ End: ${formatDate(new Date(tooltipData.y))}`;
         const { width } = chartContainerRef.current.getBoundingClientRect();
 
         // Get unique display names that are currently visible
-        // This can be removed once we remove duplicates from the backend api
         const visibleNames = new Set<string>();
 
         legendNames.forEach((series, index) => {
@@ -444,7 +502,7 @@ End: ${formatDate(new Date(tooltipData.y))}`;
       window.removeEventListener('resize', updateDimensions);
       window.removeEventListener('zoom', handleZoom);
     };
-  }, [updatedLifecycleData.length]);
+  }, [updatedLifecycleData.length, hiddenSeries, renderKey]);
 
   // Clear tooltips when mouse leaves the chart
   React.useEffect(() => {
@@ -464,17 +522,16 @@ End: ${formatDate(new Date(tooltipData.y))}`;
     };
   }, [chartContainerRef.current]);
 
-  // Calculate padding based on the longest name
+  // Calculate padding based on the longest visible name
   const calculateLeftPadding = () => {
-    if (updatedLifecycleData.length === 0) {
+    const visibleTicks = getVisibleTicks();
+
+    if (visibleTicks.length === 0) {
       return 160; // Default padding if no data
     }
 
-    // Get all names
-    const names = updatedLifecycleData.map((data) => data[0].x);
-
-    // Find the longest name
-    const longestName = names.reduce(
+    // Find the longest visible name
+    const longestName = visibleTicks.reduce(
       (longest, current) => (current.length > longest.length ? current : longest),
       ''
     );
@@ -500,6 +557,7 @@ End: ${formatDate(new Date(tooltipData.y))}`;
       {showDateTooltip && renderDateTooltip()}
 
       <Chart
+        key={renderKey} // Force re-render when renderKey changes
         legendAllowWrap
         ariaDesc="Support timelines of packages and RHEL versions"
         events={getInteractiveLegendEvents({
@@ -543,14 +601,7 @@ End: ${formatDate(new Date(tooltipData.y))}`;
         {/*Y axis with the name of each stream/operating system */}
         <ChartAxis
           showGrid
-          tickValues={fetchTicks()} // Keep all ticks
-          tickFormat={(tick) => {
-            // Check if this tick should be visible
-            const isVisible = legendNames.some(
-              (series, index) => !hiddenSeries.has(index) && series.datapoints.some((d) => d.x === tick)
-            );
-            return isVisible ? tick : ''; // Return empty string for hidden ticks
-          }}
+          tickValues={getVisibleTicks()}
           style={{
             tickLabels: {
               fontSize: () => Math.max(10, Math.min(14, chartDimensions.width / 60)),
@@ -559,25 +610,21 @@ End: ${formatDate(new Date(tooltipData.y))}`;
         />
         <ChartGroup horizontal>
           {legendNames.map((s, index) => {
-            if (s.datapoints.length === 0) {
+            // Skip rendering entirely if the series is hidden
+            if (hiddenSeries.has(index) || s.datapoints.length === 0) {
               return null;
             }
             return (
               <ChartBar
-                data={
-                  !hiddenSeries.has(index)
-                    ? s.datapoints
-                    : s.datapoints.map((d) => {
-                        return { ...d, x: null };
-                      })
-                }
-                key={`bar-${index}`}
+                data={s.datapoints}
+                key={`bar-${index}-${renderKey}`} // Include renderKey for forced re-render
                 name={`series-${index}`}
                 barWidth={10}
                 style={{
                   data: {
                     fill: getPackageColor(s.packageType),
                     stroke: getPackageColor(s.packageType),
+                    fillOpacity: hiddenSeries.has(index) ? 0.3 : 1, // Ensure proper opacity based on hidden state
                   },
                 }}
                 // Add direct event handlers for tooltips
@@ -591,6 +638,11 @@ End: ${formatDate(new Date(tooltipData.y))}`;
                             target: 'data',
                             mutation: (props) => {
                               const { datum, x, y } = props;
+
+                              // Don't show tooltip if series is hidden
+                              if (hiddenSeries.has(index)) {
+                                return null;
+                              }
 
                               // Regular bar tooltip positioning
                               const tooltipX = calculateTooltipPosition(x);

--- a/src/Components/LifecycleChart/LifecycleChart.tsx
+++ b/src/Components/LifecycleChart/LifecycleChart.tsx
@@ -450,6 +450,7 @@ End: ${formatDate(new Date(tooltipData.y))}`;
         const { width } = chartContainerRef.current.getBoundingClientRect();
 
         // Get unique display names that are currently visible
+         // This can be removed once we remove duplicates from the backend api
         const visibleNames = new Set<string>();
 
         legendNames.forEach((series, index) => {

--- a/src/Components/LifecycleChart/LifecycleChart.tsx
+++ b/src/Components/LifecycleChart/LifecycleChart.tsx
@@ -450,7 +450,7 @@ End: ${formatDate(new Date(tooltipData.y))}`;
         const { width } = chartContainerRef.current.getBoundingClientRect();
 
         // Get unique display names that are currently visible
-         // This can be removed once we remove duplicates from the backend api
+        // This can be removed once we remove duplicates from the backend api
         const visibleNames = new Set<string>();
 
         legendNames.forEach((series, index) => {

--- a/src/Components/LifecycleChartSystem/LifecycleChartSystem.tsx
+++ b/src/Components/LifecycleChartSystem/LifecycleChartSystem.tsx
@@ -30,7 +30,10 @@ interface ChartDataObject {
   name: string;
 }
 
-const LifecycleChartSystem: React.FC<LifecycleChartProps> = ({ lifecycleData, viewFilter }: LifecycleChartProps) => {
+const LifecycleChartSystem: React.FC<LifecycleChartProps> = ({
+  lifecycleData,
+  viewFilter,
+}: LifecycleChartProps) => {
   const chartContainerRef = React.useRef<HTMLDivElement>(null);
   const [chartDimensions, setChartDimensions] = React.useState({
     width: 900,
@@ -450,7 +453,7 @@ End: ${formatDate(new Date(tooltipData.y))}`;
         const { width } = chartContainerRef.current.getBoundingClientRect();
 
         // Get unique display names that are currently visible
-         // This can be removed once we remove duplicates from the backend api
+        // This can be removed once we remove duplicates from the backend api
         const visibleNames = new Set<string>();
 
         legendNames.forEach((series, index) => {


### PR DESCRIPTION
### Description
<!-- Must include 2-3 sentence summary of proposed changes -->
<!-- Must include links to impacted UI(s) or information regarding the impacted UI -->
<!-- Must include any relevant steps to reproduce (if not clear in tracked issue or story) -->
<!-- Must include RSPEED-XXX link (if proposed change involves tracked issue or story) -->
This PR now filters out any hidden item from the chart legend from the current data being supplied to the Chart. There is an issue where if all of the current chart items are hidden then the unhide button stops working. To prevent this conditions have been put in place to prevent the all items but one to be hidden from the chart legend. 
Jira link:
[RSPEED-1228](https://issues.redhat.com/browse/RSPEED-1228)

---

### Screenshots
<!-- Before and after proposed changes is ideal -->
<!-- Any key UI permutations should be captured -->
<!-- Draw attention to the area of UI that has changed -->
#### Before:
![image](https://github.com/user-attachments/assets/6e8d6273-a9e7-47d3-badf-71367d678b40)


#### After:
![image](https://github.com/user-attachments/assets/ef215199-4d8a-4769-96c6-bd55c108ee23)


---

### Checklist ☑️
- [ ] PR only fixes one issue or story <!-- open new PR for others -->
- [ ] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [ ] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [ ] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [ ] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##
