### PR TITLE
Accept new name for support ends within 3/6 months

### DIFF
--- a/src/Components/LifecycleChart/LifecycleChart.tsx
+++ b/src/Components/LifecycleChart/LifecycleChart.tsx
@@ -65,6 +65,20 @@ const LifecycleChart: React.FC<LifecycleChartProps> = ({ lifecycleData, viewFilt
   const updatedLifecycleData: ChartDataObject[][] = [];
   const years: { [key: string]: Date } = {};
 
+  // Helper function to map backend support type to display name
+  const mapSupportTypeToDisplayName = (supportType: string, dataType: string): string => {
+    if (supportType === 'Near retirement') {
+      // Map to the appropriate display name based on data type
+      if (dataType === 'appLifecycle') {
+        return 'Support ends within 6 months';
+      } else {
+        return 'Support ends within 3 months';
+      }
+    }
+    // Return the original support type for all other cases
+    return supportType;
+  };
+
   const formatChartData = (
     name: string,
     startDate: string,
@@ -73,12 +87,15 @@ const LifecycleChart: React.FC<LifecycleChartProps> = ({ lifecycleData, viewFilt
     version: string,
     numSystems: string
   ) => {
+    // Map the support type to display name based on data type
+    const displayPackageType = mapSupportTypeToDisplayName(packageType, dataType);
+
     return updatedLifecycleData.push([
       {
         x: name,
         y0: new Date(startDate),
         y: new Date(endDate),
-        packageType,
+        packageType: displayPackageType,
         version,
         numSystems,
         name: name,

--- a/src/Components/LifecycleChart/LifecycleChart.tsx
+++ b/src/Components/LifecycleChart/LifecycleChart.tsx
@@ -13,6 +13,7 @@ import {
 } from '@patternfly/react-charts';
 import { SystemLifecycleChanges } from '../../types/SystemLifecycleChanges';
 import { Stream } from '../../types/Stream';
+import { mapSupportTypeToDisplayName } from '../../utils/utils';
 
 interface LifecycleChartProps {
   lifecycleData: Stream[] | SystemLifecycleChanges[];
@@ -64,20 +65,6 @@ const LifecycleChart: React.FC<LifecycleChartProps> = ({ lifecycleData, viewFilt
   const dataType = checkDataType(lifecycleData);
   const updatedLifecycleData: ChartDataObject[][] = [];
   const years: { [key: string]: Date } = {};
-
-  // Helper function to map backend support type to display name
-  const mapSupportTypeToDisplayName = (supportType: string, dataType: string): string => {
-    if (supportType === 'Near retirement') {
-      // Map to the appropriate display name based on data type
-      if (dataType === 'appLifecycle') {
-        return 'Support ends within 6 months';
-      } else {
-        return 'Support ends within 3 months';
-      }
-    }
-    // Return the original support type for all other cases
-    return supportType;
-  };
 
   const formatChartData = (
     name: string,

--- a/src/Components/LifecycleChartSystem/LifecycleChartSystem.tsx
+++ b/src/Components/LifecycleChartSystem/LifecycleChartSystem.tsx
@@ -13,6 +13,7 @@ import {
 } from '@patternfly/react-charts';
 import { SystemLifecycleChanges } from '../../types/SystemLifecycleChanges';
 import { Stream } from '../../types/Stream';
+import { mapSupportTypeToDisplayName } from '../../utils/utils';
 
 interface LifecycleChartProps {
   lifecycleData: Stream[] | SystemLifecycleChanges[];
@@ -30,10 +31,7 @@ interface ChartDataObject {
   name: string;
 }
 
-const LifecycleChartSystem: React.FC<LifecycleChartProps> = ({
-  lifecycleData,
-  viewFilter,
-}: LifecycleChartProps) => {
+const LifecycleChartSystem: React.FC<LifecycleChartProps> = ({ lifecycleData, viewFilter }: LifecycleChartProps) => {
   const chartContainerRef = React.useRef<HTMLDivElement>(null);
   const [chartDimensions, setChartDimensions] = React.useState({
     width: 900,
@@ -67,20 +65,6 @@ const LifecycleChartSystem: React.FC<LifecycleChartProps> = ({
   const dataType = checkDataType(lifecycleData);
   const updatedLifecycleData: ChartDataObject[][] = [];
   const years: { [key: string]: Date } = {};
-
-  // Helper function to map backend support type to display name
-  const mapSupportTypeToDisplayName = (supportType: string, dataType: string): string => {
-    if (supportType === 'Near retirement') {
-      // Map to the appropriate display name based on data type
-      if (dataType === 'appLifecycle') {
-        return 'Support ends within 6 months';
-      } else {
-        return 'Support ends within 3 months';
-      }
-    }
-    // Return the original support type for all other cases
-    return supportType;
-  };
 
   const formatChartData = (
     name: string,

--- a/src/Components/LifecycleChartSystem/LifecycleChartSystem.tsx
+++ b/src/Components/LifecycleChartSystem/LifecycleChartSystem.tsx
@@ -31,7 +31,10 @@ interface ChartDataObject {
   name: string;
 }
 
-const LifecycleChartSystem: React.FC<LifecycleChartProps> = ({ lifecycleData, viewFilter }: LifecycleChartProps) => {
+const LifecycleChartSystem: React.FC<LifecycleChartProps> = ({
+  lifecycleData,
+  viewFilter,
+}: LifecycleChartProps) => {
   const chartContainerRef = React.useRef<HTMLDivElement>(null);
   const [chartDimensions, setChartDimensions] = React.useState({
     width: 900,

--- a/src/Components/LifecycleChartSystem/LifecycleChartSystem.tsx
+++ b/src/Components/LifecycleChartSystem/LifecycleChartSystem.tsx
@@ -68,6 +68,20 @@ const LifecycleChartSystem: React.FC<LifecycleChartProps> = ({
   const updatedLifecycleData: ChartDataObject[][] = [];
   const years: { [key: string]: Date } = {};
 
+  // Helper function to map backend support type to display name
+  const mapSupportTypeToDisplayName = (supportType: string, dataType: string): string => {
+    if (supportType === 'Near retirement') {
+      // Map to the appropriate display name based on data type
+      if (dataType === 'appLifecycle') {
+        return 'Support ends within 6 months';
+      } else {
+        return 'Support ends within 3 months';
+      }
+    }
+    // Return the original support type for all other cases
+    return supportType;
+  };
+
   const formatChartData = (
     name: string,
     startDate: string,
@@ -76,12 +90,15 @@ const LifecycleChartSystem: React.FC<LifecycleChartProps> = ({
     version: string,
     numSystems: string
   ) => {
+    // Map the support type to display name based on data type
+    const displayPackageType = mapSupportTypeToDisplayName(packageType, dataType);
+
     return updatedLifecycleData.push([
       {
         x: name,
         y0: new Date(startDate),
         y: new Date(endDate),
-        packageType,
+        packageType: displayPackageType,
         version,
         numSystems,
         name: name,

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -106,14 +106,14 @@ export const getNewChartName = (name: string, major: number, minor: number, life
 };
 
 export const mapSupportTypeToDisplayName = (supportType: string, dataType: string): string => {
-    if (supportType === 'Near retirement') {
-      // Map to the appropriate display name based on data type
-      if (dataType === 'appLifecycle') {
-        return 'Support ends within 6 months';
-      } else {
-        return 'Support ends within 3 months';
-      }
+  if (supportType === 'Near retirement') {
+    // Map to the appropriate display name based on data type
+    if (dataType === 'appLifecycle') {
+      return 'Support ends within 6 months';
+    } else {
+      return 'Support ends within 3 months';
     }
-    // Return the original support type for all other cases
-    return supportType;
-  };
+  }
+  // Return the original support type for all other cases
+  return supportType;
+};

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -104,3 +104,16 @@ export const getNewChartName = (name: string, major: number, minor: number, life
   const lifecycleText = getLifecycleType(lifecycleType);
   return `${name} ${lifecycleText}`;
 };
+
+export const mapSupportTypeToDisplayName = (supportType: string, dataType: string): string => {
+    if (supportType === 'Near retirement') {
+      // Map to the appropriate display name based on data type
+      if (dataType === 'appLifecycle') {
+        return 'Support ends within 6 months';
+      } else {
+        return 'Support ends within 3 months';
+      }
+    }
+    // Return the original support type for all other cases
+    return supportType;
+  };


### PR DESCRIPTION
### Description
<!-- Must include 2-3 sentence summary of proposed changes -->
<!-- Must include links to impacted UI(s) or information regarding the impacted UI -->
<!-- Must include any relevant steps to reproduce (if not clear in tracked issue or story) -->
<!-- Must include RSPEED-XXX link (if proposed change involves tracked issue or story) -->
This PR adjusts our code to handle the new "Near retirement" support type that replaces the previous "Support ends within 6 months" and "Support ends within 3 months" types. The original names are still used in the legends. 
Jira link:
[RSPEED-XXX](https://issues.redhat.com/browse/RSPEED-XXX)

---

### Screenshots
<!-- Before and after proposed changes is ideal -->
<!-- Any key UI permutations should be captured -->
<!-- Draw attention to the area of UI that has changed -->
#### Before:


#### After:


---

### Checklist ☑️
- [ ] PR only fixes one issue or story <!-- open new PR for others -->
- [ ] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [ ] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [ ] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [ ] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##
