### PR TITLE
[RSPEED-1579] Allow other legends to be hidden when there is only one legend in the chart

### DIFF
--- a/src/Components/LifecycleChart/LifecycleChart.tsx
+++ b/src/Components/LifecycleChart/LifecycleChart.tsx
@@ -249,33 +249,28 @@ const LifecycleChart: React.FC<LifecycleChartProps> = ({ lifecycleData, viewFilt
     setHiddenSeries((prevHiddenSeries) => {
       const newHiddenSeries = new Set(prevHiddenSeries);
 
-      // Get the count of series that have actual data
-      const totalVisibleSeries = legendNames.filter((s) => s.datapoints.length > 0).length;
+      // Get only series that have actual data
+      const seriesWithData = legendNames
+        .map((series, index) => ({ series, index }))
+        .filter(({ series }) => series.datapoints.length > 0);
 
-      // Convert Set to Array with proper typing
-      const hiddenIndices = Array.from(prevHiddenSeries) as number[];
-      const currentlyHiddenCount = hiddenIndices.filter((index: number) => {
-        return (
-          typeof index === 'number' &&
-          index >= 0 &&
-          index < legendNames.length &&
-          legendNames[index] &&
-          legendNames[index].datapoints.length > 0
-        );
-      }).length;
+      // Count how many series with data are currently visible
+      const currentlyVisibleSeriesWithData = seriesWithData.filter(({ index }) => !prevHiddenSeries.has(index));
 
       const isCurrentlyHidden = newHiddenSeries.has(props.index);
+      const clickedSeriesHasData = legendNames[props.index]?.datapoints.length > 0;
 
-      // If we're trying to hide the last visible series, don't allow it
-      if (!isCurrentlyHidden && currentlyHiddenCount >= totalVisibleSeries - 1) {
-        // Optionally show a message or just ignore the click
-        console.log('Cannot hide all series - at least one must remain visible');
-        return prevHiddenSeries; // Return unchanged state
+      // Only prevent hiding if:
+      // 1. The clicked series has data
+      // 2. It would be the last visible series with data
+      if (!isCurrentlyHidden && clickedSeriesHasData && currentlyVisibleSeriesWithData.length <= 1) {
+        console.log('Cannot hide all series - at least one with data must remain visible');
+        return prevHiddenSeries;
       }
 
-      // If we're trying to show a series when all are hidden, show this one and clear others
-      if (isCurrentlyHidden && currentlyHiddenCount === totalVisibleSeries) {
-        // Clear all hidden series to show everything
+      // If we're trying to show a series when all series with data are hidden,
+      // show this one and clear others
+      if (isCurrentlyHidden && currentlyVisibleSeriesWithData.length === 0) {
         return new Set<number>();
       }
 

--- a/src/Components/LifecycleChartSystem/LifecycleChartSystem.tsx
+++ b/src/Components/LifecycleChartSystem/LifecycleChartSystem.tsx
@@ -252,33 +252,28 @@ const LifecycleChartSystem: React.FC<LifecycleChartProps> = ({
     setHiddenSeries((prevHiddenSeries) => {
       const newHiddenSeries = new Set(prevHiddenSeries);
 
-      // Get the count of series that have actual data
-      const totalVisibleSeries = legendNames.filter((s) => s.datapoints.length > 0).length;
+      // Get only series that have actual data
+      const seriesWithData = legendNames
+        .map((series, index) => ({ series, index }))
+        .filter(({ series }) => series.datapoints.length > 0);
 
-      // Convert Set to Array with proper typing
-      const hiddenIndices = Array.from(prevHiddenSeries) as number[];
-      const currentlyHiddenCount = hiddenIndices.filter((index: number) => {
-        return (
-          typeof index === 'number' &&
-          index >= 0 &&
-          index < legendNames.length &&
-          legendNames[index] &&
-          legendNames[index].datapoints.length > 0
-        );
-      }).length;
+      // Count how many series with data are currently visible
+      const currentlyVisibleSeriesWithData = seriesWithData.filter(({ index }) => !prevHiddenSeries.has(index));
 
       const isCurrentlyHidden = newHiddenSeries.has(props.index);
+      const clickedSeriesHasData = legendNames[props.index]?.datapoints.length > 0;
 
-      // If we're trying to hide the last visible series, don't allow it
-      if (!isCurrentlyHidden && currentlyHiddenCount >= totalVisibleSeries - 1) {
-        // Optionally show a message or just ignore the click
-        console.log('Cannot hide all series - at least one must remain visible');
-        return prevHiddenSeries; // Return unchanged state
+      // Only prevent hiding if:
+      // 1. The clicked series has data
+      // 2. It would be the last visible series with data
+      if (!isCurrentlyHidden && clickedSeriesHasData && currentlyVisibleSeriesWithData.length <= 1) {
+        console.log('Cannot hide all series - at least one with data must remain visible');
+        return prevHiddenSeries;
       }
 
-      // If we're trying to show a series when all are hidden, show this one and clear others
-      if (isCurrentlyHidden && currentlyHiddenCount === totalVisibleSeries) {
-        // Clear all hidden series to show everything
+      // If we're trying to show a series when all series with data are hidden,
+      // show this one and clear others
+      if (isCurrentlyHidden && currentlyVisibleSeriesWithData.length === 0) {
         return new Set<number>();
       }
 


### PR DESCRIPTION
### Description
<!-- Must include 2-3 sentence summary of proposed changes -->
<!-- Must include links to impacted UI(s) or information regarding the impacted UI -->
<!-- Must include any relevant steps to reproduce (if not clear in tracked issue or story) -->
<!-- Must include RSPEED-XXX link (if proposed change involves tracked issue or story) -->
This PR improves the previous logic in place to hide series in the chart. Before it would stop the users from hiding anymore series if there is only one legend series in the chart. Now it allows those series to be hidden as long as they are not a part of the current legends displayed in the chart.

Jira link:
[RSPEED-1579](https://issues.redhat.com/browse/RSPEED-1579)

---

### Screenshots
<!-- Before and after proposed changes is ideal -->
<!-- Any key UI permutations should be captured -->
<!-- Draw attention to the area of UI that has changed -->
#### Before:


#### After:
![image](https://github.com/user-attachments/assets/027694c7-4cc1-429d-9cd8-90297f407886)


---

### Checklist ☑️
- [ ] PR only fixes one issue or story <!-- open new PR for others -->
- [ ] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [ ] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [ ] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [ ] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##
