### PR TITLE
[RSPEED-1705] Make the API calls in the Roadmap tab parallel

### DIFF
--- a/src/Components/Upcoming/Upcoming.tsx
+++ b/src/Components/Upcoming/Upcoming.tsx
@@ -125,7 +125,7 @@ const UpcomingTab: React.FC<React.PropsWithChildren> = () => {
       // Fetch both APIs in parallel
       const [allResponse, relevantResponse] = await Promise.allSettled([
         getAllUpcomingChanges(),
-        getRelevantUpcomingChanges()
+        getRelevantUpcomingChanges(),
       ]);
 
       // Process "all" data
@@ -137,7 +137,7 @@ const UpcomingTab: React.FC<React.PropsWithChildren> = () => {
           type: capitalizeFirstLetter(item.type),
         }));
         setAllUpcomingChangesData(allData);
-        setDataFetchStatus(prev => ({ ...prev, all: true }));
+        setDataFetchStatus((prev) => ({ ...prev, all: true }));
       } else {
         console.error('Error fetching all changes:', allResponse.reason);
       }
@@ -151,12 +151,16 @@ const UpcomingTab: React.FC<React.PropsWithChildren> = () => {
           type: capitalizeFirstLetter(item.type),
         }));
         setRelevantUpcomingChangesData(relevantData);
-        setDataFetchStatus(prev => ({ ...prev, relevant: true }));
+        setDataFetchStatus((prev) => ({ ...prev, relevant: true }));
       } else {
         console.error('Error fetching relevant changes:', relevantResponse.reason);
       }
 
-      return { allData, relevantData, hasErrors: allResponse.status === 'rejected' && relevantResponse.status === 'rejected' };
+      return {
+        allData,
+        relevantData,
+        hasErrors: allResponse.status === 'rejected' && relevantResponse.status === 'rejected',
+      };
     } catch (error) {
       console.error('Unexpected error in fetchBothDataSources:', error);
       throw error;
@@ -248,8 +252,12 @@ const UpcomingTab: React.FC<React.PropsWithChildren> = () => {
 
       // If we need to fetch data, use parallel fetching
       if (needsAllData || needsRelevantData) {
-        const { allData: fetchedAllData, relevantData: fetchedRelevantData, hasErrors } = await fetchBothDataSources();
-        
+        const {
+          allData: fetchedAllData,
+          relevantData: fetchedRelevantData,
+          hasErrors,
+        } = await fetchBothDataSources();
+
         if (hasErrors) {
           throw new Error('Failed to fetch data from both endpoints');
         }
@@ -278,7 +286,7 @@ const UpcomingTab: React.FC<React.PropsWithChildren> = () => {
         } else {
           setNoDataAvailable(false);
         }
-        
+
         setUpcomingChanges(relevantData);
         processData(relevantData);
       }


### PR DESCRIPTION
### Description
This PR modifies the API calls in the Roadmap tab to be parallel and removes some repeated logic.

Jira link:
[RSPEED-1705](https://issues.redhat.com/browse/RSPEED-1705)

---

### Screenshots
<!-- Before and after proposed changes is ideal -->
<!-- Any key UI permutations should be captured -->
<!-- Draw attention to the area of UI that has changed -->
#### Before:
![image](https://github.com/user-attachments/assets/63be635a-6565-465a-92e3-56631cf5bf03)


#### After:
![image](https://github.com/user-attachments/assets/def7b774-d579-4eca-a997-595e9e8f035b)


---

### Checklist ☑️
- [ ] PR only fixes one issue or story <!-- open new PR for others -->
- [ ] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [ ] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [ ] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [ ] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##
