### PR TITLE
[RSPEED-1636] Fix missing stream in table

### DIFF
--- a/src/Components/LifecycleTable/LifecycleTable.tsx
+++ b/src/Components/LifecycleTable/LifecycleTable.tsx
@@ -85,7 +85,7 @@ export const LifecycleTable: React.FunctionComponent<LifecycleTableProps> = ({
     if (!lifecycleData || lifecycleData.length === 0) {
       return '';
     }
-    if ('application_stream_name' in lifecycleData[0]) {
+    if ('display_name' in lifecycleData[0] && 'os_major' in lifecycleData[0]) {
       return 'streams';
     }
     return 'rhel';
@@ -255,7 +255,7 @@ export const LifecycleTable: React.FunctionComponent<LifecycleTableProps> = ({
 
   const renderAppLifecycleData = () => {
     return (paginatedRows as Stream[]).map((repo: Stream, index: number) => {
-      if (!repo.name || !repo.application_stream_name || !repo.os_major) {
+      if (!repo.display_name || !repo.os_major) {
         return;
       }
 


### PR DESCRIPTION
### Description
<!-- Must include 2-3 sentence summary of proposed changes -->
<!-- Must include links to impacted UI(s) or information regarding the impacted UI -->
<!-- Must include any relevant steps to reproduce (if not clear in tracked issue or story) -->
<!-- Must include RSPEED-XXX link (if proposed change involves tracked issue or story) -->
Fix the missing item(specifically `Eclipse RHEL8`) in the Lifecycle Table.

The root cause is that we expect every valid repo to have `application_stream_name`, but it seems `Eclipse RHEL8` have an empty application_stream_name that caused this repo not to be displayed in the table. The `checkDataType()` function was also revised to display the repo with no `application_stream_name`.



Jira link:
[RSPEED-1636](https://issues.redhat.com/browse/RSPEED-1636)

---

### Screenshots
<!-- Before and after proposed changes is ideal -->
<!-- Any key UI permutations should be captured -->
<!-- Draw attention to the area of UI that has changed -->
#### Before:


#### After:


---

### Checklist ☑️
- [ ] PR only fixes one issue or story <!-- open new PR for others -->
- [ ] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [ ] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [ ] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [ ] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##
