### PR TITLE
[RSPEED-1768] Fix missing status icons

### DIFF
--- a/src/Components/LifecycleTable/LifecycleTable.tsx
+++ b/src/Components/LifecycleTable/LifecycleTable.tsx
@@ -47,9 +47,7 @@ const StatusIcon: React.FunctionComponent<{ supportStatus: string }> = ({ suppor
   switch (supportStatus) {
     case 'Supported':
       return <CheckCircleIcon color="var(--pf-v5-global--success-color--100)" />;
-    case 'Support ends within 6 months':
-      return <ExclamationTriangleIcon color="var(--pf-v5-global--warning-color--100)" />;
-    case 'Support ends within 3 months':
+    case 'Near retirement':
       return <ExclamationTriangleIcon color="var(--pf-v5-global--warning-color--100)" />;
     case 'Retired':
       return <ExclamationCircleIcon color="var(--pf-v5-global--danger-color--100)" />;
@@ -286,7 +284,7 @@ export const LifecycleTable: React.FunctionComponent<LifecycleTableProps> = ({
                       padding: 0,
                       paddingLeft:
                         repo.support_status === 'Supported' ||
-                        repo.support_status === 'Support ends within 6 months' ||
+                        repo.support_status === 'Near retirement' ||
                         repo.support_status === 'Retired'
                           ? '0'
                           : '18px',
@@ -353,7 +351,7 @@ export const LifecycleTable: React.FunctionComponent<LifecycleTableProps> = ({
                       padding: 0,
                       paddingLeft:
                         repo.support_status === 'Supported' ||
-                        repo.support_status === 'Support ends within 3 months' ||
+                        repo.support_status === 'Near retirement' ||
                         repo.support_status === 'Retired'
                           ? '0'
                           : '18px',


### PR DESCRIPTION
Fix missing status icons in table. This issue was caused by changing name of the SupportStatus to the "Near retirement".

### Description
<!-- Must include 2-3 sentence summary of proposed changes -->
<!-- Must include links to impacted UI(s) or information regarding the impacted UI -->
<!-- Must include any relevant steps to reproduce (if not clear in tracked issue or story) -->
<!-- Must include RSPEED-XXX link (if proposed change involves tracked issue or story) -->
description text...

Jira link:
[RSPEED-XXX](https://issues.redhat.com/browse/RSPEED-1768)

---

### Screenshots
<!-- Before and after proposed changes is ideal -->
<!-- Any key UI permutations should be captured -->
<!-- Draw attention to the area of UI that has changed -->
#### Before:


#### After:


---

### Checklist ☑️
- [ ] PR only fixes one issue or story <!-- open new PR for others -->
- [ ] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [ ] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [ ] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [ ] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##
