### PR TITLE
[RSPEED-1578] Improper name display in csv export

### DIFF
--- a/src/Components/Lifecycle/Lifecycle.tsx
+++ b/src/Components/Lifecycle/Lifecycle.tsx
@@ -658,7 +658,7 @@ const LifecycleTab: React.FC<React.PropsWithChildren> = () => {
     ) {
       (filteredTableData as Stream[]).forEach((item: Stream) =>
         data.push({
-          Name: item.name,
+          Name: item.display_name,
           Release: item.os_major,
           'Release date': formatDate(item.start_date),
           'Retirement date': formatDate(item.end_date),


### PR DESCRIPTION
### Description
<!-- Must include 2-3 sentence summary of proposed changes -->
<!-- Must include links to impacted UI(s) or information regarding the impacted UI -->
<!-- Must include any relevant steps to reproduce (if not clear in tracked issue or story) -->
<!-- Must include RSPEED-XXX link (if proposed change involves tracked issue or story) -->
This PR fixes the csv file export pushing the "name" variable instead of the full "display_name" variable. This helps users have a clearer view of what packages are in the csv file. 
Jira link:
[RSPEED-1578](https://issues.redhat.com/browse/RSPEED-1578)

---

### Screenshots
<!-- Before and after proposed changes is ideal -->
<!-- Any key UI permutations should be captured -->
<!-- Draw attention to the area of UI that has changed -->
#### Before:
<img width="694" height="140" alt="image" src="https://github.com/user-attachments/assets/0cf90d76-c256-4811-aaed-cdf7fc486147" />


#### After:
<img width="694" height="140" alt="image" src="https://github.com/user-attachments/assets/e5e7c3e7-42c5-44c9-9759-1b18e2698b6a" />


---

### Checklist ☑️
- [ ] PR only fixes one issue or story <!-- open new PR for others -->
- [ ] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [ ] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [ ] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [ ] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##
