### PR TITLE
[RSPEED-1074] Replace the gap with NBSP to fix the legend hover spacing bug

### DIFF
--- a/src/Components/LifecycleChart/LifecycleChart.tsx
+++ b/src/Components/LifecycleChart/LifecycleChart.tsx
@@ -241,11 +241,12 @@ const LifecycleChart: React.FC<LifecycleChartProps> = ({ lifecycleData, viewFilt
   };
 
   const legendNames = React.useMemo(calculateLegendNames, [updatedLifecycleData]);
+  const LEGEND_NAME_PREFIX = '\u00A0\u00A0\u00A0'; // Nonbreakable space - fix issue with legend hover spacing bug
 
   const getLegendData = () =>
     legendNames.map((s, index) => ({
       childName: `series-${index}`,
-      name: s.packageType,
+      name: `${LEGEND_NAME_PREFIX}${s.packageType}`,
       symbol: { fill: `${getPackageColor(s.packageType)}` },
       ...getInteractiveLegendItemStyles(hiddenSeries.has(index)),
     }));
@@ -585,7 +586,16 @@ End: ${formatDate(new Date(tooltipData.y))}`;
           legendName: 'chart5-ChartLegend',
           onLegendClick: handleLegendClick,
         })}
-        legendComponent={<ChartLegend name="chart5-ChartLegend" data={getLegendData()} height={50} gutter={20} />}
+        legendComponent={
+          <ChartLegend
+            name="chart5-ChartLegend"
+            symbolSpacer={1}
+            borderPadding={{ top: 12, bottom: 0, left: 0, right: 0 }}
+            data={getLegendData()}
+            height={50}
+            gutter={20}
+          />
+        }
         legendPosition="bottom-left"
         name="chart5"
         padding={{

--- a/src/Components/LifecycleChartSystem/LifecycleChartSystem.tsx
+++ b/src/Components/LifecycleChartSystem/LifecycleChartSystem.tsx
@@ -244,11 +244,12 @@ const LifecycleChartSystem: React.FC<LifecycleChartProps> = ({
   };
 
   const legendNames = React.useMemo(calculateLegendNames, [updatedLifecycleData]);
+  const LEGEND_NAME_PREFIX = '\u00A0\u00A0\u00A0'; // Nonbreakable space - fix issue with legend hover spacing bug
 
   const getLegendData = () =>
     legendNames.map((s, index) => ({
       childName: `series-${index}`,
-      name: s.packageType,
+      name: `${LEGEND_NAME_PREFIX}${s.packageType}`,
       symbol: { fill: `${getPackageColor(s.packageType)}` },
       ...getInteractiveLegendItemStyles(hiddenSeries.has(index)),
     }));
@@ -588,7 +589,16 @@ End: ${formatDate(new Date(tooltipData.y))}`;
           legendName: 'chart5-ChartLegend',
           onLegendClick: handleLegendClick,
         })}
-        legendComponent={<ChartLegend name="chart5-ChartLegend" data={getLegendData()} height={50} gutter={20} />}
+        legendComponent={
+          <ChartLegend
+            name="chart5-ChartLegend"
+            symbolSpacer={1}
+            borderPadding={{ top: 12, bottom: 0, left: 0, right: 0 }}
+            data={getLegendData()}
+            height={50}
+            gutter={20}
+          />
+        }
         legendPosition="bottom-left"
         name="chart5"
         padding={{


### PR DESCRIPTION
### Description
Add a transparent hit to fix gaps on the legend label of the timeline on the Lifecycle page.

Jira link:
[RSPEED-1074](https://issues.redhat.com/browse/RSPEED-1074)

---

### Screenshots
<!-- Before and after proposed changes is ideal -->
<!-- Any key UI permutations should be captured -->
<!-- Draw attention to the area of UI that has changed -->
#### Before:


#### After:
<img width="1340" height="712" alt="image" src="https://github.com/user-attachments/assets/28b13d17-ec32-4e4d-a761-54a77c570685" />


---

### Checklist ☑️
- [ ] PR only fixes one issue or story <!-- open new PR for others -->
- [ ] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [ ] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [ ] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [ ] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##
