### PR TITLE
[RSPEED-1953] Fix sorting by Release in Roadmap tab

### DIFF
--- a/src/Components/UpcomingTable/UpcomingTable.tsx
+++ b/src/Components/UpcomingTable/UpcomingTable.tsx
@@ -107,22 +107,22 @@ export const UpcomingTable: React.FunctionComponent<UpcomingTableProps> = ({
     }
     return dataToSort;
   };
-  
+
   const sortData = (index: number, direction: SortByDirection, currentData: UpcomingChanges[]) => {
     return currentData.sort((a, b) => {
       const aValue = getSortableRowValues(a)[index];
       const bValue = getSortableRowValues(b)[index];
-      
+
       // Special handling for release column (index 2) - semantic version sorting
       if (index === 2 && typeof aValue === 'string' && typeof bValue === 'string') {
         const parseVersion = (version: string) => {
-          const parts = version.split('.').map(part => parseInt(part, 10) || 0);
+          const parts = version.split('.').map((part) => parseInt(part, 10) || 0);
           return { major: parts[0] || 0, minor: parts[1] || 0 };
         };
-        
+
         const versionA = parseVersion(aValue);
         const versionB = parseVersion(bValue);
-        
+
         // Compare major versions first
         if (versionA.major > versionB.major) return direction === 'asc' ? 1 : -1;
         if (versionA.major < versionB.major) return direction === 'asc' ? -1 : 1;
@@ -131,7 +131,7 @@ export const UpcomingTable: React.FunctionComponent<UpcomingTableProps> = ({
         if (versionA.minor < versionB.minor) return direction === 'asc' ? -1 : 1;
         return 0;
       }
-      
+
       // Default sorting for other columns
       if (typeof aValue === 'number') {
         // Numeric sort
@@ -148,7 +148,7 @@ export const UpcomingTable: React.FunctionComponent<UpcomingTableProps> = ({
       }
     });
   };
-  
+
   const getSortParams = (columnIndex: number): ThProps['sort'] => ({
     sortBy: {
       index: activeSortIndex,

--- a/src/Components/UpcomingTable/UpcomingTable.tsx
+++ b/src/Components/UpcomingTable/UpcomingTable.tsx
@@ -115,21 +115,10 @@ export const UpcomingTable: React.FunctionComponent<UpcomingTableProps> = ({
 
       // Special handling for release column (index 2) - semantic version sorting
       if (index === 2 && typeof aValue === 'string' && typeof bValue === 'string') {
-        const parseVersion = (version: string) => {
-          const parts = version.split('.').map((part) => parseInt(part, 10) || 0);
-          return { major: parts[0] || 0, minor: parts[1] || 0 };
-        };
-
-        const versionA = parseVersion(aValue);
-        const versionB = parseVersion(bValue);
-
-        // Compare major versions first
-        if (versionA.major > versionB.major) return direction === 'asc' ? 1 : -1;
-        if (versionA.major < versionB.major) return direction === 'asc' ? -1 : 1;
-        // If major versions are equal, compare minor versions
-        if (versionA.minor > versionB.minor) return direction === 'asc' ? 1 : -1;
-        if (versionA.minor < versionB.minor) return direction === 'asc' ? -1 : 1;
-        return 0;
+        const aNum = parseFloat(aValue);
+        const bNum = parseFloat(bValue);
+        const comparison = aNum - bNum;
+        return direction === 'asc' ? comparison : -comparison;
       }
 
       // Default sorting for other columns

--- a/src/Components/UpcomingTable/UpcomingTable.tsx
+++ b/src/Components/UpcomingTable/UpcomingTable.tsx
@@ -107,11 +107,32 @@ export const UpcomingTable: React.FunctionComponent<UpcomingTableProps> = ({
     }
     return dataToSort;
   };
-
+  
   const sortData = (index: number, direction: SortByDirection, currentData: UpcomingChanges[]) => {
     return currentData.sort((a, b) => {
       const aValue = getSortableRowValues(a)[index];
       const bValue = getSortableRowValues(b)[index];
+      
+      // Special handling for release column (index 2) - semantic version sorting
+      if (index === 2 && typeof aValue === 'string' && typeof bValue === 'string') {
+        const parseVersion = (version: string) => {
+          const parts = version.split('.').map(part => parseInt(part, 10) || 0);
+          return { major: parts[0] || 0, minor: parts[1] || 0 };
+        };
+        
+        const versionA = parseVersion(aValue);
+        const versionB = parseVersion(bValue);
+        
+        // Compare major versions first
+        if (versionA.major > versionB.major) return direction === 'asc' ? 1 : -1;
+        if (versionA.major < versionB.major) return direction === 'asc' ? -1 : 1;
+        // If major versions are equal, compare minor versions
+        if (versionA.minor > versionB.minor) return direction === 'asc' ? 1 : -1;
+        if (versionA.minor < versionB.minor) return direction === 'asc' ? -1 : 1;
+        return 0;
+      }
+      
+      // Default sorting for other columns
       if (typeof aValue === 'number') {
         // Numeric sort
         if (direction === 'asc') {
@@ -127,7 +148,7 @@ export const UpcomingTable: React.FunctionComponent<UpcomingTableProps> = ({
       }
     });
   };
-
+  
   const getSortParams = (columnIndex: number): ThProps['sort'] => ({
     sortBy: {
       index: activeSortIndex,


### PR DESCRIPTION
### Description
<!-- Must include 2-3 sentence summary of proposed changes -->
<!-- Must include links to impacted UI(s) or information regarding the impacted UI -->
<!-- Must include any relevant steps to reproduce (if not clear in tracked issue or story) -->
<!-- Must include RSPEED-XXX link (if proposed change involves tracked issue or story) -->
Fixes an issue with the sortData function not sorting Release values properly in the Roadmap tab. Release values were taken in as strings so two digit numbers were not sorted correctly. This PR converts the strings to numbers and separates them into major and minor version so they can be compared correctly. 
Jira link:
[RSPEED-1953](https://issues.redhat.com/browse/RSPEED-1953)

---

### Screenshots
<!-- Before and after proposed changes is ideal -->
<!-- Any key UI permutations should be captured -->
<!-- Draw attention to the area of UI that has changed -->
#### Before:
<img width="162" height="287" alt="image" src="https://github.com/user-attachments/assets/62d21afd-12c9-4a5d-b0d3-d7e964e21c08" />


#### After:
<img width="162" height="287" alt="image" src="https://github.com/user-attachments/assets/d826fede-9eb8-41eb-9903-eba7f3259818" />


---

### Checklist ☑️
- [ ] PR only fixes one issue or story <!-- open new PR for others -->
- [ ] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [ ] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [ ] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [ ] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##
