### PR TITLE
Remove redundant API call from upcoming

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -8,7 +8,6 @@ import {
   DR_RELEASE_NOTES,
   DR_RELEVANT_LIFECYCLE_APPSTREAMS,
   DR_RELEVANT_LIFECYCLE_SYSTEMS,
-  DR_RELEVANT_UPCOMING,
   INVENTORY_API_ROOT,
   INVENTORY_HOSTS_ROOT,
 } from './constants';
@@ -58,35 +57,6 @@ export const getRelevantReleaseNotes = async (major: number, minor: number, keyw
 
 export const getAllUpcomingChanges = async () => {
   const path = DR_API.concat(DR_ALL_UPCOMING);
-  const response = await axios
-    .get(path, {
-      validateStatus: function (status) {
-        return status === 200;
-      },
-    })
-    .catch(function (error) {
-      if (error.response.data.detail) {
-        if (error.response.status) {
-          throw new ApiError(error.response.data.detail, error.response.status);
-        }
-        throw new ApiError(error.response.data.detail);
-      } else if (error.request.response) {
-        if (error.request.status) {
-          throw new ApiError(error.request.response, error.request.status);
-        }
-        throw new ApiError(error.request.response);
-      } else if (error.detail) {
-        throw new ApiError(error.detail);
-      } else {
-        throw new ApiError(error.message);
-      }
-    });
-
-  return getResponseOrError(response);
-};
-
-export const getRelevantUpcomingChanges = async () => {
-  const path = DR_API.concat(DR_RELEVANT_UPCOMING);
   const response = await axios
     .get(path, {
       validateStatus: function (status) {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -6,7 +6,6 @@ export const DR_RELEVANT_LIFECYCLE_APPSTREAMS = '/relevant/lifecycle/app-streams
 export const DR_ALL_LIFECYCLE_APPSTREAMS = '/lifecycle/app-streams/streams';
 
 export const DR_ALL_UPCOMING = '/relevant/upcoming-changes?all=true';
-export const DR_RELEVANT_UPCOMING = '/relevant/upcoming-changes';
 
 export const INVENTORY_API_ROOT = '/api/inventory/v1';
 export const INVENTORY_HOSTS_ROOT = '/hosts';


### PR DESCRIPTION
There was a api call which can be avoided by filtering all data.

### Description
<!-- Must include 2-3 sentence summary of proposed changes -->
<!-- Must include links to impacted UI(s) or information regarding the impacted UI -->
<!-- Must include any relevant steps to reproduce (if not clear in tracked issue or story) -->
<!-- Must include RSPEED-XXX link (if proposed change involves tracked issue or story) -->
description text...

Jira link:
[RSPEED-XXX](https://issues.redhat.com/browse/RSPEED-XXX)

---

### Screenshots
<!-- Before and after proposed changes is ideal -->
<!-- Any key UI permutations should be captured -->
<!-- Draw attention to the area of UI that has changed -->
#### Before:


#### After:


---

### Checklist ☑️
- [ ] PR only fixes one issue or story <!-- open new PR for others -->
- [ ] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [ ] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [ ] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [ ] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##
