### PR TITLE
[RSPEED-1957] Fix incorrect start/end lifecycle month

### DIFF
--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -42,6 +42,7 @@ export const formatDate = (date: string | null) => {
   return dateAsDate?.toLocaleDateString('en-US', {
     year: 'numeric',
     month: 'short',
+    timeZone: 'UTC',
   });
 };
 


### PR DESCRIPTION
Lifecycle start/end date was incorrectly displayed. Dates like 2025-11-01 or 2025-1-31 could be incorrectly displayed as Oct 2025 or Feb 2025.

This was caused because of timezone issues and the date was incorrectly displayed as different month based on the local timezone.

You can experiment with it using developer console e.g. in chrome:
- in devtools open the menu under 3 dots in top right corner, sensors, timezone override - select some timezone there

<img width="619" height="316" alt="Screenshot From 2025-09-29 23-56-23" src="https://github.com/user-attachments/assets/87675185-b378-48f9-a42f-bd5bf481e9a0" />

### Description
<!-- Must include 2-3 sentence summary of proposed changes -->
<!-- Must include links to impacted UI(s) or information regarding the impacted UI -->
<!-- Must include any relevant steps to reproduce (if not clear in tracked issue or story) -->
<!-- Must include RSPEED-XXX link (if proposed change involves tracked issue or story) -->
description text...

Jira link:
[RSPEED-1957](https://issues.redhat.com/browse/RSPEED-1957)

---

### Screenshots
<!-- Before and after proposed changes is ideal -->
<!-- Any key UI permutations should be captured -->
<!-- Draw attention to the area of UI that has changed -->
#### Before:


#### After:


---

### Checklist ☑️
- [ ] PR only fixes one issue or story <!-- open new PR for others -->
- [ ] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [ ] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [ ] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [ ] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##
