### PR TITLE
[RSPEED-2859] Update Roadmap UI to work with notifications

### DIFF
--- a/src/Components/Upcoming/Upcoming.tsx
+++ b/src/Components/Upcoming/Upcoming.tsx
@@ -274,6 +274,8 @@ const UpcomingTab: React.FC<React.PropsWithChildren> = () => {
       }
 
       // Determine which data to display based on current view filter
+      const dataToUse = currentViewFilter === 'all' ? allData : relevantData;
+
       if (currentViewFilter === 'all') {
         setUpcomingChanges(allData);
         processData(allData);
@@ -293,28 +295,28 @@ const UpcomingTab: React.FC<React.PropsWithChildren> = () => {
       // Apply URL parameters
       const newFilters = { ...filtersForURL };
 
-      // Apply URL parameters if this is the initial load
+      // Apply URL parameters if this is the initial load - use local data instead of state
       if (nameParam) {
         const name = decodeURIComponent(nameParam);
         setCurrentNameFilters(name);
         newFilters['name'] = name;
       }
-      if (releaseParam && isValidRelease(upcomingChanges, decodeURIComponent(releaseParam))) {
+      if (releaseParam && isValidRelease(dataToUse, decodeURIComponent(releaseParam))) {
         const release = decodeURIComponent(releaseParam).split(',');
         setCurrentReleaseFilters(release);
         newFilters['release'] = release;
       }
-      if (typeParam && isValidType(upcomingChanges, decodeURIComponent(typeParam))) {
+      if (typeParam && isValidType(dataToUse, decodeURIComponent(typeParam))) {
         const type = new Set(decodeURIComponent(typeParam).split(','));
         setCurrentTypeFilters(type);
         newFilters['type'] = type;
       }
-      if (dateParam && isValidDate(upcomingChanges, decodeURIComponent(dateParam))) {
+      if (dateParam && isValidDate(dataToUse, decodeURIComponent(dateParam))) {
         const date = decodeURIComponent(dateParam);
         setCurrentDateFilter(date);
         newFilters['date'] = date;
       }
-      if (addedToRoadmapParam && isValidAddedToRoadmap(upcomingChanges, decodeURIComponent(addedToRoadmapParam))) {
+      if (addedToRoadmapParam && isValidAddedToRoadmap(dataToUse, decodeURIComponent(addedToRoadmapParam))) {
         const addedToRoadmap = decodeURIComponent(addedToRoadmapParam);
         setCurrentAddedToRoadmapFilter(addedToRoadmap);
         newFilters['addedToRoadmap'] = addedToRoadmap;

--- a/src/Components/Upcoming/Upcoming.tsx
+++ b/src/Components/Upcoming/Upcoming.tsx
@@ -96,7 +96,9 @@ const UpcomingTab: React.FC<React.PropsWithChildren> = () => {
   };
 
   const isValidAddedToRoadmap = (data: UpcomingChanges[], addedToRoadmap: string) => {
-    return Array.from(new Set(data.map((repo) => repo.details?.dateAdded).filter(Boolean))).includes(addedToRoadmap);
+    return Array.from(new Set(data.map((repo) => repo.details?.dateAdded).filter(Boolean))).includes(
+      addedToRoadmap
+    );
   };
 
   // Type comes in as Type1,Type2,Type3 or Type1 or any other permutation
@@ -341,10 +343,6 @@ const UpcomingTab: React.FC<React.PropsWithChildren> = () => {
 
     fetchData(initialViewFilter);
   }, []);
-
-  const deprecationId = 'filter-by-type-deprecation';
-  const changeId = 'filter-by-type-change';
-  const additionId = 'filter-by-type-addition';
 
   const resetFilters = () => {
     setCurrentTypeFilters(new Set());

--- a/src/Components/Upcoming/Upcoming.tsx
+++ b/src/Components/Upcoming/Upcoming.tsx
@@ -38,6 +38,7 @@ export const UPCOMING_COLUMN_NAMES = {
   name: 'Name',
   type: 'Type',
   release: 'Release',
+  addedToRoadmap: 'Added to roadmap',
   date: 'Release date',
 };
 
@@ -65,6 +66,7 @@ const UpcomingTab: React.FC<React.PropsWithChildren> = () => {
   const [currentDateFilter, setCurrentDateFilter] = React.useState('');
   const [currentNameFilter, setCurrentNameFilters] = React.useState('');
   const [currentReleaseFilters, setCurrentReleaseFilters] = React.useState<string[]>([]);
+  const [currentAddedToRoadmapFilter, setCurrentAddedToRoadmapFilter] = React.useState('');
   const [error, setError] = React.useState<ErrorObject>();
   const [noAllDataAvailable, setNoAllDataAvailable] = useState<boolean>(false);
   const [noDataAvailable, setNoDataAvailable] = useState<boolean>(false);
@@ -78,6 +80,7 @@ const UpcomingTab: React.FC<React.PropsWithChildren> = () => {
   const typeParam = searchParams.get('type');
   const releaseParam = searchParams.get('release');
   const dateParam = searchParams.get('date');
+  const addedToRoadmapParam = searchParams.get('addedToRoadmap');
   const viewFilterParam = searchParams.get('viewFilter');
 
   // Type comes in as Release1,Release2 or Release1 or any other permutation
@@ -90,6 +93,10 @@ const UpcomingTab: React.FC<React.PropsWithChildren> = () => {
 
   const isValidDate = (data: UpcomingChanges[], date: string) => {
     return Array.from(new Set(data.map((repo) => repo.date))).includes(date);
+  };
+
+  const isValidAddedToRoadmap = (data: UpcomingChanges[], addedToRoadmap: string) => {
+    return Array.from(new Set(data.map((repo) => repo.details?.dateAdded).filter(Boolean))).includes(addedToRoadmap);
   };
 
   // Type comes in as Type1,Type2,Type3 or Type1 or any other permutation
@@ -306,6 +313,11 @@ const UpcomingTab: React.FC<React.PropsWithChildren> = () => {
         setCurrentDateFilter(date);
         newFilters['date'] = date;
       }
+      if (addedToRoadmapParam && isValidAddedToRoadmap(upcomingChanges, decodeURIComponent(addedToRoadmapParam))) {
+        const addedToRoadmap = decodeURIComponent(addedToRoadmapParam);
+        setCurrentAddedToRoadmapFilter(addedToRoadmap);
+        newFilters['addedToRoadmap'] = addedToRoadmap;
+      }
 
       // Include view filter in URL
       newFilters['viewFilter'] = selectedViewFilter;
@@ -339,6 +351,7 @@ const UpcomingTab: React.FC<React.PropsWithChildren> = () => {
     setCurrentDateFilter('');
     setCurrentNameFilters('');
     setCurrentReleaseFilters([]);
+    setCurrentAddedToRoadmapFilter('');
 
     // Don't reset to relevant if no relevant data available
     if (!noDataAvailable) {
@@ -571,6 +584,7 @@ const UpcomingTab: React.FC<React.PropsWithChildren> = () => {
           initialDateFilter={currentDateFilter}
           initialNameFilter={currentNameFilter}
           initialReleaseFilters={currentReleaseFilters}
+          initialAddedToRoadmapFilter={currentAddedToRoadmapFilter}
           filtersForURL={filtersForURL}
           setFiltersForURL={updateChildFilters}
           selectedViewFilter={selectedViewFilter}

--- a/src/Components/Upcoming/Upcoming.tsx
+++ b/src/Components/Upcoming/Upcoming.tsx
@@ -95,10 +95,9 @@ const UpcomingTab: React.FC<React.PropsWithChildren> = () => {
     return Array.from(new Set(data.map((repo) => repo.date))).includes(date);
   };
 
-  const isValidAddedToRoadmap = (data: UpcomingChanges[], addedToRoadmap: string) => {
-    return Array.from(new Set(data.map((repo) => repo.details?.dateAdded).filter(Boolean))).includes(
-      addedToRoadmap
-    );
+  const isValidAddedToRoadmap = (_data: UpcomingChanges[], addedToRoadmap: string) => {
+    const validRanges = ['lastMonthToDate', 'last90Days', 'lastYear', 'moreThan1YearAgo'];
+    return validRanges.includes(addedToRoadmap);
   };
 
   // Type comes in as Type1,Type2,Type3 or Type1 or any other permutation
@@ -183,7 +182,7 @@ const UpcomingTab: React.FC<React.PropsWithChildren> = () => {
     }
 
     setSelectedViewFilter(filter);
-    const newFilters = structuredClone(filtersForURL);
+    const newFilters = { ...filtersForURL };
     newFilters['viewFilter'] = filter;
     setFiltersForURL(newFilters);
     setSearchParams(buildURL(newFilters));
@@ -228,7 +227,7 @@ const UpcomingTab: React.FC<React.PropsWithChildren> = () => {
       setSelectedViewFilter('all');
 
       // Update URL and filters
-      const newFilters = structuredClone(filtersForURL);
+      const newFilters = { ...filtersForURL };
       newFilters['viewFilter'] = 'all';
       setFiltersForURL(newFilters);
       setSearchParams(buildURL(newFilters));
@@ -292,7 +291,7 @@ const UpcomingTab: React.FC<React.PropsWithChildren> = () => {
       }
 
       // Apply URL parameters
-      const newFilters = structuredClone(filtersForURL);
+      const newFilters = { ...filtersForURL };
 
       // Apply URL parameters if this is the initial load
       if (nameParam) {
@@ -375,14 +374,14 @@ const UpcomingTab: React.FC<React.PropsWithChildren> = () => {
     }
 
     // Update filters for URL
-    const newFilters: any = structuredClone(DEFAULT_FILTERS);
+    const newFilters: any = { ...DEFAULT_FILTERS };
     newFilters['viewFilter'] = noDataAvailable ? 'all' : 'relevant';
     setFiltersForURL(newFilters);
     setSearchParams(buildURL(newFilters));
   };
 
   const setTypeParam = (type: Set<string>) => {
-    const newFilters = structuredClone(filtersForURL);
+    const newFilters = { ...filtersForURL };
     newFilters['type'] = type;
     setFiltersForURL(newFilters);
     setSearchParams(buildURL(newFilters));

--- a/src/Components/UpcomingRow/UpcomingRow.scss
+++ b/src/Components/UpcomingRow/UpcomingRow.scss
@@ -14,6 +14,7 @@
   flex-direction: column;
   gap: 16px;
   padding-left: 16px;
+  padding-bottom: 20px;
 }
 
 .drf-lifecycle__upcoming-row-type {

--- a/src/Components/UpcomingRow/UpcomingRow.test.tsx
+++ b/src/Components/UpcomingRow/UpcomingRow.test.tsx
@@ -244,7 +244,6 @@ describe('TableRow', () => {
       expect(screen.getByText(repoWithDetails.details!.summary)).toBeInTheDocument();
       expect(screen.getByText('Potentially affected systems')).toBeInTheDocument();
       expect(screen.getByText('Tracking ticket')).toBeInTheDocument();
-      expect(screen.getByText('Date added')).toBeInTheDocument();
       expect(screen.getByText('Last modified')).toBeInTheDocument();
     });
   });

--- a/src/Components/UpcomingRow/UpcomingRow.tsx
+++ b/src/Components/UpcomingRow/UpcomingRow.tsx
@@ -14,6 +14,7 @@ export const columnNames = {
   name: 'Name',
   type: 'Type',
   release: 'Release',
+  addedToRoadmap: 'Added to roadmap',
   date: 'Date',
 };
 
@@ -112,6 +113,9 @@ export const TableRow: React.FunctionComponent<TableRowProps> = ({
           <Td dataLabel={columnNames.release} modifier="truncate">
             {repo.release}
           </Td>
+          <Td dataLabel={columnNames.addedToRoadmap} modifier="truncate">
+            {repo.details?.dateAdded ?? ''}
+          </Td>
           <Td dataLabel={columnNames.date} modifier="truncate">
             {formatDate(repo.date)}
           </Td>
@@ -119,7 +123,7 @@ export const TableRow: React.FunctionComponent<TableRowProps> = ({
         {repo.details ? (
           <Tr isExpanded={isExpanded}>
             {!childIsFullWidth ? <Td /> : null}
-            <Td className="drf-lifecycle__upcoming-row" dataLabel="Summary" noPadding colSpan={4}>
+            <Td className="drf-lifecycle__upcoming-row" dataLabel="Summary" noPadding colSpan={5}>
               <ExpandableRowContent>
                 <div className="drf-lifecycle__upcoming-row-text-container">
                   <Content className="drf-lifecycle__upcoming-row-text">
@@ -127,14 +131,19 @@ export const TableRow: React.FunctionComponent<TableRowProps> = ({
                   </Content>
 
                   <Content className="drf-lifecycle__upcoming-row-text">
-                    <Content component={ContentVariants.dl} style={{ gridRowGap: '0px', gridColumnGap: '120px' }}>
-                      <Content
-                        component={ContentVariants.dt}
-                        style={{ paddingBottom: '16px', whiteSpace: 'nowrap' }}
-                      >
+                    <Content
+                      component={ContentVariants.dl}
+                      style={{
+                        display: 'grid',
+                        gridTemplateColumns: 'max-content 1fr',
+                        gridRowGap: '8px',
+                        gridColumnGap: '16px',
+                      }}
+                    >
+                      <Content component={ContentVariants.dt} style={{ whiteSpace: 'nowrap' }}>
                         Potentially affected systems
                       </Content>
-                      <Content component={ContentVariants.dd}>
+                      <Content component={ContentVariants.dd} style={{ margin: 0 }}>
                         {repo.details.potentiallyAffectedSystemsCount &&
                         repo.details.potentiallyAffectedSystemsCount > 0 ? (
                           <Button
@@ -144,27 +153,18 @@ export const TableRow: React.FunctionComponent<TableRowProps> = ({
                               setModalDataName(String(repo.package));
                               setModalData(repo.details?.potentiallyAffectedSystemsDetail);
                             }}
-                            style={{
-                              marginTop: '-4px',
-                              fontSize: '14px',
-                              marginLeft: '-16px',
-                            }}
+                            isInline
                           >
                             {repo.details.potentiallyAffectedSystemsCount}
                           </Button>
                         ) : (
-                          <span
-                            style={{
-                              fontSize: '14px',
-                              marginLeft: '-2px',
-                            }}
-                          >
-                            {repo.details.potentiallyAffectedSystemsCount}
-                          </span>
+                          <span>{repo.details.potentiallyAffectedSystemsCount}</span>
                         )}
                       </Content>
-                      <Content component={ContentVariants.dt}>Tracking ticket</Content>
-                      <Content component={ContentVariants.dd}>
+                      <Content component={ContentVariants.dt} style={{ whiteSpace: 'nowrap' }}>
+                        Tracking ticket
+                      </Content>
+                      <Content component={ContentVariants.dd} style={{ margin: 0 }}>
                         <a
                           href={`https://issues.redhat.com/browse/${repo.details.trainingTicket}`}
                           rel="noreferrer"
@@ -172,10 +172,12 @@ export const TableRow: React.FunctionComponent<TableRowProps> = ({
                           {repo.details.trainingTicket}
                         </a>
                       </Content>
-                      <Content component={ContentVariants.dt}>Date added</Content>
-                      <Content component={ContentVariants.dd}>{repo.details.dateAdded}</Content>
-                      <Content component={ContentVariants.dt}>Last modified</Content>
-                      <Content component={ContentVariants.dd}>{repo.details.lastModified}</Content>
+                      <Content component={ContentVariants.dt} style={{ whiteSpace: 'nowrap' }}>
+                        Last modified
+                      </Content>
+                      <Content component={ContentVariants.dd} style={{ margin: 0 }}>
+                        {repo.details.lastModified}
+                      </Content>
                     </Content>
                   </Content>
                 </div>

--- a/src/Components/UpcomingRow/UpcomingRow.tsx
+++ b/src/Components/UpcomingRow/UpcomingRow.tsx
@@ -41,7 +41,6 @@ export const TableRow: React.FunctionComponent<TableRowProps> = ({
   const [modalData, setModalData] = React.useState<SystemsDetail[]>();
 
   let childIsFullWidth = false;
-  let childHasNoPadding = false;
 
   const onToggle = () => {
     if (isExpanded) {
@@ -83,7 +82,6 @@ export const TableRow: React.FunctionComponent<TableRowProps> = ({
   if (repo.details) {
     const { detailFormat } = repo.details;
     childIsFullWidth = [1, 3].includes(detailFormat);
-    childHasNoPadding = [2, 3].includes(detailFormat);
   }
 
   return (

--- a/src/Components/UpcomingTable/UpcomingTable.test.tsx
+++ b/src/Components/UpcomingTable/UpcomingTable.test.tsx
@@ -24,6 +24,8 @@ jest.mock('./UpcomingTableFilters', () => {
     setDateSelection,
     releaseSelections,
     setReleaseSelections,
+    addedToRoadmapSelection,
+    setAddedToRoadmapSelection,
     selectedViewFilter,
     handleViewFilterChange,
     noDataAvailable,
@@ -44,6 +46,7 @@ jest.mock('./UpcomingTableFilters', () => {
         <div data-testid="type-selections">{Array.from(typeSelections).join(',')}</div>
         <div data-testid="date-selection">{dateSelection}</div>
         <div data-testid="release-selections">{releaseSelections.join(',')}</div>
+        <div data-testid="added-to-roadmap-selection">{addedToRoadmapSelection}</div>
         <div data-testid="selected-view-filter">{selectedViewFilter}</div>
         <div data-testid="no-data-available">{noDataAvailable.toString()}</div>
         <button data-testid="set-type-filter" onClick={() => setTypeSelections(new Set(['Deprecation']))}>
@@ -54,6 +57,9 @@ jest.mock('./UpcomingTableFilters', () => {
         </button>
         <button data-testid="set-release-filter" onClick={() => setReleaseSelections(['9.0'])}>
           Set Release Filter
+        </button>
+        <button data-testid="set-added-to-roadmap-filter" onClick={() => setAddedToRoadmapSelection('2024-07-09')}>
+          Set Added to Roadmap Filter
         </button>
         <button data-testid="change-view-filter" onClick={() => handleViewFilterChange('all')}>
           Change View Filter
@@ -140,6 +146,7 @@ const mockColumnNames = {
   name: 'Name',
   type: 'Type',
   release: 'Release',
+  addedToRoadmap: 'Added to roadmap',
   date: 'Release date',
 };
 
@@ -151,6 +158,7 @@ const defaultProps = {
   initialNameFilter: '',
   initialDateFilter: '',
   initialReleaseFilters: [],
+  initialAddedToRoadmapFilter: '',
   filtersForURL: DEFAULT_FILTERS,
   setFiltersForURL: jest.fn(),
   selectedViewFilter: 'relevant',

--- a/src/Components/UpcomingTable/UpcomingTable.tsx
+++ b/src/Components/UpcomingTable/UpcomingTable.tsx
@@ -27,6 +27,7 @@ interface UpcomingTableProps {
     type: string;
     release: string;
     date: string;
+    addedToRoadmap: string;
   };
   details?: {
     summary: string;
@@ -41,6 +42,7 @@ interface UpcomingTableProps {
   initialNameFilter: string;
   initialDateFilter: string;
   initialReleaseFilters: string[];
+  initialAddedToRoadmapFilter: string;
   filtersForURL: Filter;
   setFiltersForURL: (filters: Filter) => void;
   selectedViewFilter: string;
@@ -56,6 +58,7 @@ export const UpcomingTable: React.FunctionComponent<UpcomingTableProps> = ({
   initialNameFilter,
   initialDateFilter,
   initialReleaseFilters,
+  initialAddedToRoadmapFilter,
   filtersForURL,
   setFiltersForURL,
   selectedViewFilter,
@@ -66,6 +69,7 @@ export const UpcomingTable: React.FunctionComponent<UpcomingTableProps> = ({
   const [typeSelections, setTypeSelections] = useState<Set<string>>(initialTypeFilters);
   const [dateSelection, setDateSelection] = useState(initialDateFilter ?? '');
   const [releaseSelections, setReleaseSelections] = useState<string[]>(initialReleaseFilters ?? []);
+  const [addedToRoadmapSelection, setAddedToRoadmapSelection] = useState(initialAddedToRoadmapFilter ?? '');
   const [page, setPage] = React.useState(1);
   const [perPage, setPerPage] = React.useState(10);
   const [paginatedRows, setPaginatedRows] = React.useState(data.slice(0, 10));
@@ -96,9 +100,14 @@ export const UpcomingTable: React.FunctionComponent<UpcomingTableProps> = ({
     setReleaseSelections(initialReleaseFilters);
   }, [initialReleaseFilters]);
 
+  useEffect(() => {
+    setAddedToRoadmapSelection(initialAddedToRoadmapFilter);
+  }, [initialAddedToRoadmapFilter]);
+
   const getSortableRowValues = (repo: UpcomingChanges): (string | number)[] => {
     const { name, type, release, date } = repo;
-    return [name, type, release, date];
+    const addedToRoadmap = repo.details?.dateAdded ?? '';
+    return [name, type, release, addedToRoadmap, date];
   };
 
   const sortFilteredData = (dataToSort: UpcomingChanges[]) => {
@@ -193,6 +202,40 @@ export const UpcomingTable: React.FunctionComponent<UpcomingTableProps> = ({
     />
   );
 
+  // Helper function to check if a date falls within a date range
+  const isDateInRange = (dateString: string | undefined, rangeType: string): boolean => {
+    if (!dateString) return false;
+
+    const date = new Date(dateString);
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+
+    switch (rangeType) {
+      case 'lastMonthToDate': {
+        // From the 1st of the previous month to today
+        const firstOfLastMonth = new Date(today.getFullYear(), today.getMonth() - 1, 1);
+        return date >= firstOfLastMonth && date <= today;
+      }
+      case 'last90Days': {
+        const ninetyDaysAgo = new Date(today);
+        ninetyDaysAgo.setDate(today.getDate() - 90);
+        return date >= ninetyDaysAgo && date <= today;
+      }
+      case 'lastYear': {
+        const oneYearAgo = new Date(today);
+        oneYearAgo.setFullYear(today.getFullYear() - 1);
+        return date >= oneYearAgo && date <= today;
+      }
+      case 'moreThan1YearAgo': {
+        const oneYearAgo = new Date(today);
+        oneYearAgo.setFullYear(today.getFullYear() - 1);
+        return date < oneYearAgo;
+      }
+      default:
+        return false;
+    }
+  };
+
   const onFilter = (repo: UpcomingChanges) => {
     // Search name with search value
     let searchValueInput: RegExp;
@@ -212,11 +255,16 @@ export const UpcomingTable: React.FunctionComponent<UpcomingTableProps> = ({
     // Search date with date selection
     const matchesDateValue = repo.date.toLowerCase() === dateSelection.toLowerCase();
 
+    // Search added to roadmap with date range
+    const matchesAddedToRoadmapValue =
+      addedToRoadmapSelection === '' || isDateInRange(repo.details?.dateAdded, addedToRoadmapSelection);
+
     return (
       (searchValue === '' || matchesNameValue) &&
       (releaseSelections.length === 0 || matchesReleaseValue) &&
       (typeSelections.size === 0 || matchesTypeValue) &&
-      (dateSelection === '' || matchesDateValue)
+      (dateSelection === '' || matchesDateValue) &&
+      matchesAddedToRoadmapValue
     );
   };
 
@@ -225,6 +273,7 @@ export const UpcomingTable: React.FunctionComponent<UpcomingTableProps> = ({
     setSearchValue('');
     setReleaseSelections([]);
     setDateSelection('');
+    setAddedToRoadmapSelection('');
     setPage(1);
     setFiltersForURL(DEFAULT_FILTERS);
   };
@@ -263,7 +312,7 @@ export const UpcomingTable: React.FunctionComponent<UpcomingTableProps> = ({
     setPage(1);
     setSortedFilteredData(sortedData);
     setPaginatedRows(sortedData.slice(0, perPage));
-  }, [searchValue, typeSelections, dateSelection, releaseSelections]);
+  }, [searchValue, typeSelections, dateSelection, releaseSelections, addedToRoadmapSelection]);
 
   const releaseUniqueOptions = Array.from(new Set(data.map((repo) => repo.release))).map((release) => ({
     release: release,
@@ -328,6 +377,8 @@ export const UpcomingTable: React.FunctionComponent<UpcomingTableProps> = ({
         setDateSelection={setDateSelection}
         releaseSelections={releaseSelections}
         setReleaseSelections={setReleaseSelections}
+        addedToRoadmapSelection={addedToRoadmapSelection}
+        setAddedToRoadmapSelection={setAddedToRoadmapSelection}
         releaseOptions={releaseUniqueOptions}
         dateOptions={dateUniqueOptions}
         typeOptions={typeUniqueOptions}
@@ -377,6 +428,9 @@ export const UpcomingTable: React.FunctionComponent<UpcomingTableProps> = ({
                 {columnNames.release}
               </Th>
               <Th width={10} sort={getSortParams(3)}>
+                {columnNames.addedToRoadmap}
+              </Th>
+              <Th width={10} sort={getSortParams(4)}>
                 {columnNames.date}
               </Th>
             </Tr>
@@ -385,7 +439,7 @@ export const UpcomingTable: React.FunctionComponent<UpcomingTableProps> = ({
         {filteredData.length === 0 ? (
           <Tbody>
             <Tr>
-              <Td colSpan={4}>
+              <Td colSpan={5}>
                 <Bullseye>{emptyState}</Bullseye>
               </Td>
             </Tr>

--- a/src/Components/UpcomingTable/UpcomingTableFilters.test.tsx
+++ b/src/Components/UpcomingTable/UpcomingTableFilters.test.tsx
@@ -1,0 +1,332 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import UpcomingTableFilters from './UpcomingTableFilters';
+import { DEFAULT_FILTERS } from '../../utils/utils';
+
+const mockHandleSetPage = jest.fn();
+const mockHandlePerPageSelect = jest.fn();
+const mockResetFilters = jest.fn();
+const mockSetSearchValue = jest.fn();
+const mockSetTypeSelections = jest.fn();
+const mockSetDateSelection = jest.fn();
+const mockSetReleaseSelections = jest.fn();
+const mockSetAddedToRoadmapSelection = jest.fn();
+const mockResetTypeFilter = jest.fn();
+const mockSetFiltersForURL = jest.fn();
+const mockHandleViewFilterChange = jest.fn();
+const mockDownloadCSV = jest.fn();
+
+const defaultProps = {
+  itemCount: 50,
+  resetFilters: mockResetFilters,
+  searchValue: '',
+  setSearchValue: mockSetSearchValue,
+  handleSetPage: mockHandleSetPage,
+  handlePerPageSelect: mockHandlePerPageSelect,
+  page: 1,
+  perPage: 10,
+  typeSelections: new Set<string>(),
+  setTypeSelections: mockSetTypeSelections,
+  dateSelection: '',
+  setDateSelection: mockSetDateSelection,
+  releaseSelections: [],
+  setReleaseSelections: mockSetReleaseSelections,
+  addedToRoadmapSelection: '',
+  setAddedToRoadmapSelection: mockSetAddedToRoadmapSelection,
+  releaseOptions: [{ release: '9.5' }, { release: '9.6' }, { release: '10.0' }],
+  dateOptions: [{ date: 'Nov 2024' }, { date: 'Dec 2024' }],
+  typeOptions: [{ type: 'Addition' }, { type: 'Deprecation' }, { type: 'Change' }],
+  resetTypeFilter: mockResetTypeFilter,
+  filtersForURL: DEFAULT_FILTERS,
+  setFiltersForURL: mockSetFiltersForURL,
+  selectedViewFilter: 'relevant',
+  handleViewFilterChange: mockHandleViewFilterChange,
+  noDataAvailable: false,
+  downloadCSV: mockDownloadCSV,
+  canDownloadCSV: true,
+};
+
+describe('UpcomingTableFilters', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('Basic Rendering', () => {
+    test('renders all filter components', () => {
+      render(<UpcomingTableFilters {...defaultProps} />);
+
+      // Should render attribute selector
+      expect(screen.getByRole('button', { name: 'Name' })).toBeInTheDocument();
+
+      // Should render pagination button
+      const paginationButtons = screen.getAllByRole('button', { name: /1 - 10 of 50/i });
+      expect(paginationButtons.length).toBeGreaterThan(0);
+    });
+
+    test('renders view filter toggle group', () => {
+      render(<UpcomingTableFilters {...defaultProps} />);
+
+      expect(screen.getByText('Relevant only')).toBeInTheDocument();
+      expect(screen.getByText('All')).toBeInTheDocument();
+    });
+
+    test('renders download CSV button', () => {
+      render(<UpcomingTableFilters {...defaultProps} />);
+
+      // Use test ID or class selector since PatternFly button may not have accessible name
+      const buttons = screen.getAllByRole('button');
+      expect(buttons.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('Search Filter', () => {
+    test('displays search value', () => {
+      render(<UpcomingTableFilters {...defaultProps} searchValue="test search" />);
+
+      const searchInput = screen.getByPlaceholderText('Filter by name');
+      expect(searchInput).toHaveValue('test search');
+    });
+
+    test('calls setSearchValue when search input changes', () => {
+      render(<UpcomingTableFilters {...defaultProps} />);
+
+      const searchInput = screen.getByPlaceholderText('Filter by name');
+      fireEvent.change(searchInput, { target: { value: 'Node.js' } });
+
+      expect(mockSetSearchValue).toHaveBeenCalledWith('Node.js');
+    });
+
+    test('calls setFiltersForURL when search input changes', () => {
+      render(<UpcomingTableFilters {...defaultProps} />);
+
+      const searchInput = screen.getByPlaceholderText('Filter by name');
+      fireEvent.change(searchInput, { target: { value: 'Python' } });
+
+      expect(mockSetFiltersForURL).toHaveBeenCalled();
+    });
+  });
+
+  describe('View Filter', () => {
+    test('shows "Relevant only" as selected by default', () => {
+      render(<UpcomingTableFilters {...defaultProps} selectedViewFilter="relevant" />);
+
+      const relevantButton = screen.getByRole('button', { name: 'Relevant only' });
+      expect(relevantButton).toBeInTheDocument();
+    });
+
+    test('shows "All" as selected when view filter is "all"', () => {
+      render(<UpcomingTableFilters {...defaultProps} selectedViewFilter="all" />);
+
+      const allButton = screen.getByRole('button', { name: 'All' });
+      expect(allButton).toBeInTheDocument();
+    });
+
+    test('calls handleViewFilterChange when clicking "All"', () => {
+      render(<UpcomingTableFilters {...defaultProps} />);
+
+      const allButton = screen.getByRole('button', { name: 'All' });
+      fireEvent.click(allButton);
+
+      expect(mockHandleViewFilterChange).toHaveBeenCalledWith('all');
+    });
+
+    test('disables "Relevant only" when noDataAvailable is true', () => {
+      render(<UpcomingTableFilters {...defaultProps} noDataAvailable={true} />);
+
+      const relevantButton = screen.getByRole('button', { name: 'Relevant only' });
+      expect(relevantButton).toHaveAttribute('disabled');
+    });
+  });
+
+  describe('Type Filter', () => {
+    test('opens type filter dropdown when clicked', () => {
+      render(<UpcomingTableFilters {...defaultProps} />);
+
+      // Open attribute menu first
+      const filterButton = screen.getByRole('button', { name: /Name/i });
+      fireEvent.click(filterButton);
+
+      // Select Type from dropdown
+      const typeOption = screen.getByText('Type');
+      fireEvent.click(typeOption);
+
+      // Now open the type filter
+      const typeFilterButton = screen.getByRole('button', { name: /Filter by type/i });
+      fireEvent.click(typeFilterButton);
+
+      // Check if type options are visible
+      expect(screen.getByText('Addition')).toBeInTheDocument();
+      expect(screen.getByText('Deprecation')).toBeInTheDocument();
+      expect(screen.getByText('Change')).toBeInTheDocument();
+    });
+
+    test('displays selected type filters', () => {
+      const typeSelections = new Set(['Addition', 'Deprecation']);
+      render(<UpcomingTableFilters {...defaultProps} typeSelections={typeSelections} />);
+
+      // Type chips should be visible when types are selected
+      expect(screen.getByText('Addition')).toBeInTheDocument();
+      expect(screen.getByText('Deprecation')).toBeInTheDocument();
+    });
+  });
+
+  describe('Release Filter', () => {
+    test('opens release filter dropdown when clicked', () => {
+      render(<UpcomingTableFilters {...defaultProps} />);
+
+      // Open attribute menu
+      const filterButton = screen.getByRole('button', { name: /Name/i });
+      fireEvent.click(filterButton);
+
+      // Select Release
+      const releaseOption = screen.getByText('Release');
+      fireEvent.click(releaseOption);
+
+      // Open release filter
+      const releaseFilterButton = screen.getByRole('button', { name: /Filter by release/i });
+      fireEvent.click(releaseFilterButton);
+
+      // Check if release options are visible
+      expect(screen.getByText('9.5')).toBeInTheDocument();
+      expect(screen.getByText('9.6')).toBeInTheDocument();
+      expect(screen.getByText('10.0')).toBeInTheDocument();
+    });
+
+    test('displays selected release filters', () => {
+      render(<UpcomingTableFilters {...defaultProps} releaseSelections={['9.5', '10.0']} />);
+
+      expect(screen.getByText('9.5')).toBeInTheDocument();
+      expect(screen.getByText('10.0')).toBeInTheDocument();
+    });
+  });
+
+  describe('Date Filter', () => {
+    test('opens date filter dropdown when clicked', () => {
+      render(<UpcomingTableFilters {...defaultProps} />);
+
+      // Open attribute menu
+      const filterButton = screen.getByRole('button', { name: /Name/i });
+      fireEvent.click(filterButton);
+
+      // Select Release date
+      const dateOption = screen.getByText('Release date');
+      fireEvent.click(dateOption);
+
+      // Open date filter
+      const dateFilterButton = screen.getByRole('button', { name: /Filter by release date/i });
+      fireEvent.click(dateFilterButton);
+
+      // Check if date options are visible
+      expect(screen.getByText('Nov 2024')).toBeInTheDocument();
+      expect(screen.getByText('Dec 2024')).toBeInTheDocument();
+    });
+
+    test('displays selected date filter', () => {
+      render(<UpcomingTableFilters {...defaultProps} dateSelection="Nov 2024" />);
+
+      expect(screen.getByText('Nov 2024')).toBeInTheDocument();
+    });
+  });
+
+  describe('Added to Roadmap Filter', () => {
+    test('opens added to roadmap filter dropdown when clicked', () => {
+      render(<UpcomingTableFilters {...defaultProps} />);
+
+      // Open attribute menu
+      const filterButton = screen.getByRole('button', { name: /Name/i });
+      fireEvent.click(filterButton);
+
+      // Select Added to roadmap
+      const addedToRoadmapOption = screen.getByText('Added to roadmap');
+      fireEvent.click(addedToRoadmapOption);
+
+      // Open filter
+      const addedFilterButton = screen.getByRole('button', { name: /Filter by date added/i });
+      fireEvent.click(addedFilterButton);
+
+      // Check if options are visible
+      expect(screen.getByText('Last month to date')).toBeInTheDocument();
+      expect(screen.getByText('Last 90 days')).toBeInTheDocument();
+      expect(screen.getByText('Last year')).toBeInTheDocument();
+      expect(screen.getByText('More than 1 year ago')).toBeInTheDocument();
+    });
+
+    test('displays selected added to roadmap filter with readable label', () => {
+      render(<UpcomingTableFilters {...defaultProps} addedToRoadmapSelection="last90Days" />);
+
+      expect(screen.getByText('Last 90 days')).toBeInTheDocument();
+    });
+  });
+
+  describe('Download CSV', () => {
+    test('renders download button', () => {
+      render(<UpcomingTableFilters {...defaultProps} />);
+
+      // Just verify component renders without errors
+      expect(screen.getByText('Relevant only')).toBeInTheDocument();
+    });
+  });
+
+  describe('Pagination', () => {
+    test('displays correct item count', () => {
+      render(<UpcomingTableFilters {...defaultProps} itemCount={150} page={1} perPage={20} />);
+
+      const paginationButtons = screen.getAllByRole('button', { name: /1 - 20 of 150/i });
+      expect(paginationButtons.length).toBeGreaterThan(0);
+    });
+
+    test('displays correct page range', () => {
+      render(<UpcomingTableFilters {...defaultProps} itemCount={100} page={3} perPage={10} />);
+
+      const paginationButtons = screen.getAllByRole('button', { name: /21 - 30 of 100/i });
+      expect(paginationButtons.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('Reset Filters', () => {
+    test('calls resetFilters when clear all filters is clicked', () => {
+      render(<UpcomingTableFilters {...defaultProps} searchValue="test" typeSelections={new Set(['Addition'])} />);
+
+      const clearButton = screen.getByRole('button', { name: /clear all filters/i });
+      fireEvent.click(clearButton);
+
+      expect(mockResetFilters).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Attribute Menu', () => {
+    test('switches between filter attributes', () => {
+      render(<UpcomingTableFilters {...defaultProps} />);
+
+      // Initially shows Name
+      expect(screen.getByRole('button', { name: /Name/i })).toBeInTheDocument();
+
+      // Open menu
+      const filterButton = screen.getByRole('button', { name: /Name/i });
+      fireEvent.click(filterButton);
+
+      // Select Type
+      const typeOption = screen.getByText('Type');
+      fireEvent.click(typeOption);
+
+      // Should now show Type filter
+      expect(screen.getByRole('button', { name: /Filter by type/i })).toBeInTheDocument();
+    });
+
+    test('has all filter options in attribute menu', () => {
+      render(<UpcomingTableFilters {...defaultProps} />);
+
+      // Open menu
+      const filterButton = screen.getByRole('button', { name: 'Name' });
+      fireEvent.click(filterButton);
+
+      const allTextElements = screen.getAllByText('Name');
+      expect(allTextElements.length).toBeGreaterThan(0);
+      expect(screen.getByText('Type')).toBeInTheDocument();
+      expect(screen.getByText('Release')).toBeInTheDocument();
+      expect(screen.getByText('Release date')).toBeInTheDocument();
+      expect(screen.getByText('Added to roadmap')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/Components/UpcomingTable/UpcomingTableFilters.tsx
+++ b/src/Components/UpcomingTable/UpcomingTableFilters.tsx
@@ -52,6 +52,8 @@ interface UpcomingTableFiltersProps {
   setDateSelection: (value: string) => void;
   releaseSelections: string[];
   setReleaseSelections: (values: string[]) => void;
+  addedToRoadmapSelection: string;
+  setAddedToRoadmapSelection: (value: string) => void;
   releaseOptions: {
     release: string;
   }[];
@@ -86,6 +88,8 @@ export const UpcomingTableFilters: React.FunctionComponent<UpcomingTableFiltersP
   setDateSelection,
   releaseSelections,
   setReleaseSelections,
+  addedToRoadmapSelection,
+  setAddedToRoadmapSelection,
   releaseOptions,
   dateOptions,
   typeOptions,
@@ -101,7 +105,8 @@ export const UpcomingTableFilters: React.FunctionComponent<UpcomingTableFiltersP
   const [isReleaseMenuOpen, setIsReleaseMenuOpen] = useState<boolean>(false);
   const [isDateMenuOpen, setIsDateMenuOpen] = useState<boolean>(false);
   const [isTypeMenuOpen, setIsTypeMenuOpen] = useState<boolean>(false);
-  const [activeAttributeMenu, setActiveAttributeMenu] = useState<'Name' | 'Type' | 'Release' | 'Date'>('Name');
+  const [isAddedToRoadmapMenuOpen, setIsAddedToRoadmapMenuOpen] = useState<boolean>(false);
+  const [activeAttributeMenu, setActiveAttributeMenu] = useState<'Name' | 'Type' | 'Release' | 'Release date' | 'Added to roadmap'>('Name');
   const [isAttributeMenuOpen, setIsAttributeMenuOpen] = useState(false);
 
   const buildPagination = (variant: 'bottom' | 'top' | PaginationVariant, isCompact: boolean) => (
@@ -225,7 +230,7 @@ export const UpcomingTableFilters: React.FunctionComponent<UpcomingTableFiltersP
             } as React.CSSProperties
           }
         >
-          Filter by date
+          Filter by release date
         </MenuToggle>
       )}
       ouiaId="attribute-search-type-menu"
@@ -235,6 +240,73 @@ export const UpcomingTableFilters: React.FunctionComponent<UpcomingTableFiltersP
         {dateOptions.map((option) => (
           <DropdownItem key={option.date} isSelected={dateSelection === option.date} itemId={option.date}>
             {option.date}
+          </DropdownItem>
+        ))}
+      </DropdownList>
+    </Dropdown>
+  );
+
+  const onAddedToRoadmapToggleClick = (ev: React.MouseEvent) => {
+    setIsAddedToRoadmapMenuOpen(!isAddedToRoadmapMenuOpen);
+  };
+
+  function onAddedToRoadmapSelect(event: React.MouseEvent | undefined, itemId: string | number | undefined) {
+    if (typeof itemId === 'undefined') {
+      return;
+    }
+    const itemIdAsString = itemId.toString();
+    setAddedToRoadmapSelection(itemIdAsString);
+    setIsAddedToRoadmapMenuOpen(!isAddedToRoadmapMenuOpen);
+    const newFilters = structuredClone(filtersForURL);
+    newFilters['addedToRoadmap'] = itemIdAsString;
+    setFiltersForURL(newFilters);
+  }
+
+  const addedToRoadmapFilterOptions = [
+    { label: 'Last month to date', value: 'lastMonthToDate' },
+    { label: 'Last 90 days', value: 'last90Days' },
+    { label: 'Last year', value: 'lastYear' },
+    { label: 'More than 1 year ago', value: 'moreThan1YearAgo' },
+  ];
+
+  // Get label for added to roadmap filter value
+  const getAddedToRoadmapLabel = (value: string): string => {
+    const option = addedToRoadmapFilterOptions.find((opt) => opt.value === value);
+    return option ? option.label : value;
+  };
+
+  const addedToRoadmapSelect = (
+    <Dropdown
+      isOpen={isAddedToRoadmapMenuOpen}
+      id="attribute-search-added-to-roadmap-menu"
+      onSelect={onAddedToRoadmapSelect}
+      selected={addedToRoadmapSelection}
+      onOpenChange={(isOpen: boolean) => setIsAddedToRoadmapMenuOpen(isOpen)}
+      toggle={(toggleRef) => (
+        <MenuToggle
+          ref={toggleRef}
+          onClick={onAddedToRoadmapToggleClick}
+          isExpanded={isAddedToRoadmapMenuOpen}
+          style={
+            {
+              width: '200px',
+            } as React.CSSProperties
+          }
+        >
+          Filter by date added
+        </MenuToggle>
+      )}
+      ouiaId="attribute-search-added-to-roadmap-menu"
+      shouldFocusToggleOnSelect
+    >
+      <DropdownList>
+        {addedToRoadmapFilterOptions.map((option) => (
+          <DropdownItem
+            key={option.value}
+            isSelected={addedToRoadmapSelection === option.value}
+            itemId={option.value}
+          >
+            {option.label}
           </DropdownItem>
         ))}
       </DropdownList>
@@ -310,7 +382,7 @@ export const UpcomingTableFilters: React.FunctionComponent<UpcomingTableFiltersP
     <Dropdown
       isOpen={isAttributeMenuOpen}
       onSelect={(_ev, itemId) => {
-        setActiveAttributeMenu(itemId?.toString() as 'Name' | 'Type' | 'Release' | 'Date');
+        setActiveAttributeMenu(itemId?.toString() as 'Name' | 'Type' | 'Release' | 'Release date' | 'Added to roadmap');
         setIsAttributeMenuOpen(!isAttributeMenuOpen);
       }}
       onOpenChange={(isOpen: boolean) => setIsAttributeMenuOpen(isOpen)}
@@ -337,8 +409,11 @@ export const UpcomingTableFilters: React.FunctionComponent<UpcomingTableFiltersP
         <DropdownItem value="Release" key="release">
           Release
         </DropdownItem>
-        <DropdownItem value="Date" key="date">
-          Date
+        <DropdownItem value="Release date" key="date">
+          Release date
+        </DropdownItem>
+        <DropdownItem value="Added to roadmap" key="addedToRoadmap">
+          Added to roadmap
         </DropdownItem>
       </DropdownList>
     </Dropdown>
@@ -362,6 +437,13 @@ export const UpcomingTableFilters: React.FunctionComponent<UpcomingTableFiltersP
     setDateSelection('');
     const newFilters = structuredClone(filtersForURL);
     delete newFilters['date'];
+    setFiltersForURL(newFilters);
+  };
+
+  const resetAddedToRoadmap = () => {
+    setAddedToRoadmapSelection('');
+    const newFilters = structuredClone(filtersForURL);
+    delete newFilters['addedToRoadmap'];
     setFiltersForURL(newFilters);
   };
 
@@ -422,10 +504,19 @@ export const UpcomingTableFilters: React.FunctionComponent<UpcomingTableFiltersP
               labels={dateSelection !== '' ? [dateSelection] : ([] as string[])}
               deleteLabel={resetDate}
               deleteLabelGroup={resetDate}
-              categoryName="Date"
-              showToolbarItem={activeAttributeMenu === 'Date'}
+              categoryName="Release date"
+              showToolbarItem={activeAttributeMenu === 'Release date'}
             >
               {dateSelect}
+            </ToolbarFilter>
+            <ToolbarFilter
+              labels={addedToRoadmapSelection !== '' ? [getAddedToRoadmapLabel(addedToRoadmapSelection)] : ([] as string[])}
+              deleteLabel={resetAddedToRoadmap}
+              deleteLabelGroup={resetAddedToRoadmap}
+              categoryName="Added to roadmap"
+              showToolbarItem={activeAttributeMenu === 'Added to roadmap'}
+            >
+              {addedToRoadmapSelect}
             </ToolbarFilter>
             <ToolbarItem>
               <Form>

--- a/src/Components/UpcomingTable/UpcomingTableFilters.tsx
+++ b/src/Components/UpcomingTable/UpcomingTableFilters.tsx
@@ -151,7 +151,7 @@ export const UpcomingTableFilters: React.FunctionComponent<UpcomingTableFiltersP
       : [releaseStr, ...releaseSelections];
 
     setReleaseSelections(selections);
-    const newFilters = structuredClone(filtersForURL);
+    const newFilters = { ...filtersForURL };
     newFilters['release'] = selections;
     setFiltersForURL(newFilters);
   }
@@ -209,7 +209,7 @@ export const UpcomingTableFilters: React.FunctionComponent<UpcomingTableFiltersP
     const itemIdAsString = itemId.toString();
     setDateSelection(itemIdAsString);
     setIsDateMenuOpen(!isDateMenuOpen);
-    const newFilters = structuredClone(filtersForURL);
+    const newFilters = { ...filtersForURL };
     newFilters['date'] = itemIdAsString;
     setFiltersForURL(newFilters);
   }
@@ -259,7 +259,7 @@ export const UpcomingTableFilters: React.FunctionComponent<UpcomingTableFiltersP
     const itemIdAsString = itemId.toString();
     setAddedToRoadmapSelection(itemIdAsString);
     setIsAddedToRoadmapMenuOpen(!isAddedToRoadmapMenuOpen);
-    const newFilters = structuredClone(filtersForURL);
+    const newFilters = { ...filtersForURL };
     newFilters['addedToRoadmap'] = itemIdAsString;
     setFiltersForURL(newFilters);
   }
@@ -330,7 +330,7 @@ export const UpcomingTableFilters: React.FunctionComponent<UpcomingTableFiltersP
       : new Set([typeStr, ...typeSelections]);
 
     setTypeSelections(selections);
-    const newFilters = structuredClone(filtersForURL);
+    const newFilters = { ...filtersForURL };
     newFilters['type'] = selections;
     setFiltersForURL(newFilters);
   }
@@ -425,28 +425,28 @@ export const UpcomingTableFilters: React.FunctionComponent<UpcomingTableFiltersP
 
   const resetName = () => {
     setSearchValue('');
-    const newFilters = structuredClone(filtersForURL);
+    const newFilters = { ...filtersForURL };
     newFilters['name'] = '';
     setFiltersForURL(newFilters);
   };
 
   const resetRelease = () => {
     setReleaseSelections([]);
-    const newFilters = structuredClone(filtersForURL);
+    const newFilters = { ...filtersForURL };
     delete newFilters['release'];
     setFiltersForURL(newFilters);
   };
 
   const resetDate = () => {
     setDateSelection('');
-    const newFilters = structuredClone(filtersForURL);
+    const newFilters = { ...filtersForURL };
     delete newFilters['date'];
     setFiltersForURL(newFilters);
   };
 
   const resetAddedToRoadmap = () => {
     setAddedToRoadmapSelection('');
-    const newFilters = structuredClone(filtersForURL);
+    const newFilters = { ...filtersForURL };
     delete newFilters['addedToRoadmap'];
     setFiltersForURL(newFilters);
   };
@@ -458,7 +458,7 @@ export const UpcomingTableFilters: React.FunctionComponent<UpcomingTableFiltersP
       value={searchValue}
       onChange={(_event, value) => {
         setSearchValue(value);
-        const newFilters = structuredClone(filtersForURL);
+        const newFilters = { ...filtersForURL };
         newFilters['name'] = value;
         setFiltersForURL(newFilters);
       }}
@@ -485,7 +485,7 @@ export const UpcomingTableFilters: React.FunctionComponent<UpcomingTableFiltersP
               labels={[...typeSelections]}
               deleteLabel={(category, chip) => onTypeMenuSelect(undefined, chip as string)}
               deleteLabelGroup={() => {
-                const newFilters = structuredClone(filtersForURL);
+                const newFilters = { ...filtersForURL };
                 delete newFilters['type'];
                 setFiltersForURL(newFilters);
                 resetTypeFilter();

--- a/src/Components/UpcomingTable/UpcomingTableFilters.tsx
+++ b/src/Components/UpcomingTable/UpcomingTableFilters.tsx
@@ -106,7 +106,9 @@ export const UpcomingTableFilters: React.FunctionComponent<UpcomingTableFiltersP
   const [isDateMenuOpen, setIsDateMenuOpen] = useState<boolean>(false);
   const [isTypeMenuOpen, setIsTypeMenuOpen] = useState<boolean>(false);
   const [isAddedToRoadmapMenuOpen, setIsAddedToRoadmapMenuOpen] = useState<boolean>(false);
-  const [activeAttributeMenu, setActiveAttributeMenu] = useState<'Name' | 'Type' | 'Release' | 'Release date' | 'Added to roadmap'>('Name');
+  const [activeAttributeMenu, setActiveAttributeMenu] = useState<
+    'Name' | 'Type' | 'Release' | 'Release date' | 'Added to roadmap'
+  >('Name');
   const [isAttributeMenuOpen, setIsAttributeMenuOpen] = useState(false);
 
   const buildPagination = (variant: 'bottom' | 'top' | PaginationVariant, isCompact: boolean) => (
@@ -382,7 +384,9 @@ export const UpcomingTableFilters: React.FunctionComponent<UpcomingTableFiltersP
     <Dropdown
       isOpen={isAttributeMenuOpen}
       onSelect={(_ev, itemId) => {
-        setActiveAttributeMenu(itemId?.toString() as 'Name' | 'Type' | 'Release' | 'Release date' | 'Added to roadmap');
+        setActiveAttributeMenu(
+          itemId?.toString() as 'Name' | 'Type' | 'Release' | 'Release date' | 'Added to roadmap'
+        );
         setIsAttributeMenuOpen(!isAttributeMenuOpen);
       }}
       onOpenChange={(isOpen: boolean) => setIsAttributeMenuOpen(isOpen)}
@@ -510,7 +514,11 @@ export const UpcomingTableFilters: React.FunctionComponent<UpcomingTableFiltersP
               {dateSelect}
             </ToolbarFilter>
             <ToolbarFilter
-              labels={addedToRoadmapSelection !== '' ? [getAddedToRoadmapLabel(addedToRoadmapSelection)] : ([] as string[])}
+              labels={
+                addedToRoadmapSelection !== ''
+                  ? [getAddedToRoadmapLabel(addedToRoadmapSelection)]
+                  : ([] as string[])
+              }
               deleteLabel={resetAddedToRoadmap}
               deleteLabelGroup={resetAddedToRoadmap}
               categoryName="Added to roadmap"

--- a/src/types/Filter.ts
+++ b/src/types/Filter.ts
@@ -6,6 +6,7 @@ export interface Filter {
   type?: Set<string>;
   release?: string[];
   date?: string;
+  addedToRoadmap?: string;
   chartOrder?: string;
   versions?: string[];
   statuses?: string[];

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -90,6 +90,9 @@ export const buildURL = (filter: Filter) => {
   if (filter['release'] && filter['release'].length > 0) {
     encodedData += `&release=${filter['release'].join(',')}`;
   }
+  if (filter['addedToRoadmap']) {
+    encodedData += `&addedToRoadmap=${filter['addedToRoadmap']}`;
+  }
   return encodedData;
 };
 


### PR DESCRIPTION
### Description

- New Column: Added "Added to roadmap" column positioned before "Release date"
- Date Range Filter: Added custom filter dropdown with options:
    1. Last month to date
    2. Last 90 days
    3. Last year
    4. More than 1 year ago
- Filter Label: Updated button text to "Filter by date added"
- Accordion Cleanup: Removed "Date added" from expandable row details (now only in main table)
- Layout Fix: Fixed alignment issues in accordion view for "Potentially affected systems" field

### Technical Details:

- Updated Filter interface to include addedToRoadmap field
- Implemented date range filtering logic using isDateInRange() helper
- Updated table colspan from 4 to 5 to accommodate new column
- Fixed description list grid layout with proper two-column structure
- Updated test data in backend with 15+ diverse entries for testing

### Testing:

- All filters work correctly with URL parameter support
- Column sorting functions properly
- Accordion view displays consistent spacing for all row types
- Build completes successfully with no errors

Jira link:
[RSPEED-2859](https://issues.redhat.com/browse/RSPEED-2859)

---

### Screenshots

https://github.com/user-attachments/assets/d9a64ad5-917b-4751-8806-e7b85018df48




---

### Checklist ☑️
- [x] PR only fixes one issue or story <!-- open new PR for others -->
- [ ] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [x] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [x] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [ ] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##


[RSPEED-2859]: https://redhat.atlassian.net/browse/RSPEED-2859?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ