### PR TITLE
Add Dark mode support for Lifecycle and Roadmap tabs

### DIFF
--- a/src/Components/Lifecycle/Lifecycle.scss
+++ b/src/Components/Lifecycle/Lifecycle.scss
@@ -1,4 +1,4 @@
-@import "~@redhat-cloud-services/frontend-components-utilities/styles/variables";
+@import '~@redhat-cloud-services/frontend-components-utilities/styles/variables';
 
 .sample-component {
   font-size: $ins-fontSize;

--- a/src/Components/Lifecycle/Lifecycle.scss
+++ b/src/Components/Lifecycle/Lifecycle.scss
@@ -7,7 +7,7 @@
 }
 
 .pf-v6-c-sidebar {
-  background-color: white;
+  background-color: var(--pf-t--global--background--color--primary--default);
 }
 
 .pf-v6-c-sidebar__main {

--- a/src/Components/LifecycleChart/LifecycleChart.test.tsx
+++ b/src/Components/LifecycleChart/LifecycleChart.test.tsx
@@ -134,4 +134,63 @@ describe('LifecycleChart', () => {
     // Should be called again with the re-render
     expect(mockUseChartDataAttributes.mock.calls.length).toBeGreaterThan(initialCallCount);
   });
+
+  it('should render tooltip when tooltip data is set', () => {
+    const { container } = render(<LifecycleChart lifecycleData={mockLifecycleData} />);
+
+    // The chart container should be rendered
+    const chartContainer = container.querySelector('.drf-lifecycle__chart');
+    expect(chartContainer).toBeInTheDocument();
+  });
+
+  it('should handle data with Unknown dates', () => {
+    const dataWithUnknownDates: Stream[] = [
+      {
+        name: 'stream-unknown',
+        display_name: 'Stream Unknown',
+        start_date: 'Unknown',
+        end_date: 'Unknown',
+        support_status: 'supported',
+        os_major: 9,
+        os_minor: 0,
+        count: 1,
+        os_lifecycle: 'active',
+        application_stream_name: 'stream-unknown',
+        rolling: false,
+        related: false,
+        systems_detail: [],
+      },
+    ];
+
+    render(<LifecycleChart lifecycleData={dataWithUnknownDates} />);
+    expect(screen.getByTestId('chart')).toBeInTheDocument();
+  });
+
+  it('should render ChartLine component for current date indicator', () => {
+    render(<LifecycleChart lifecycleData={mockLifecycleData} />);
+    expect(screen.getByTestId('chart-line')).toBeInTheDocument();
+  });
+
+  it('should handle null dates in data', () => {
+    const dataWithNullDates = [
+      {
+        name: 'stream-null',
+        display_name: 'Stream Null',
+        start_date: null as unknown as string,
+        end_date: null as unknown as string,
+        support_status: 'supported',
+        os_major: 9,
+        os_minor: 0,
+        count: 1,
+        os_lifecycle: 'active',
+        application_stream_name: 'stream-null',
+        rolling: false,
+        related: false,
+        systems_detail: [],
+      },
+    ] as Stream[];
+
+    render(<LifecycleChart lifecycleData={dataWithNullDates} />);
+    expect(screen.getByTestId('chart')).toBeInTheDocument();
+  });
 });

--- a/src/Components/LifecycleChart/LifecycleChart.test.tsx
+++ b/src/Components/LifecycleChart/LifecycleChart.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import LifecycleChart from './LifecycleChart';
 import { useChartDataAttributes } from '../../utils/utils';
 import { Stream } from '../../types/Stream';
@@ -191,6 +191,81 @@ describe('LifecycleChart', () => {
     ] as Stream[];
 
     render(<LifecycleChart lifecycleData={dataWithNullDates} />);
+    expect(screen.getByTestId('chart')).toBeInTheDocument();
+  });
+
+  it('should handle mouse events on chart container', () => {
+    const { container } = render(<LifecycleChart lifecycleData={mockLifecycleData} />);
+    const chartContainer = container.querySelector('.drf-lifecycle__chart');
+
+    expect(chartContainer).toBeInTheDocument();
+
+    if (chartContainer) {
+      // Simulate mouse leave to test tooltip clearing
+      act(() => {
+        fireEvent.mouseLeave(chartContainer);
+      });
+      expect(chartContainer).toBeInTheDocument();
+    }
+  });
+
+  it('should track mouse position for tooltip rendering', () => {
+    render(<LifecycleChart lifecycleData={mockLifecycleData} />);
+
+    // Simulate mouse move to update position tracking
+    act(() => {
+      fireEvent.mouseMove(window, { clientX: 100, clientY: 200 });
+    });
+
+    expect(screen.getByTestId('chart')).toBeInTheDocument();
+  });
+
+  it('should handle resize events', () => {
+    render(<LifecycleChart lifecycleData={mockLifecycleData} />);
+
+    // Simulate window resize
+    act(() => {
+      fireEvent(window, new Event('resize'));
+    });
+
+    expect(screen.getByTestId('chart')).toBeInTheDocument();
+  });
+
+  it('should render with different support status types', () => {
+    const mixedData: Stream[] = [
+      {
+        name: 'retired-stream',
+        display_name: 'Retired Stream',
+        start_date: '2019-01-01',
+        end_date: '2020-01-01',
+        support_status: 'retired',
+        os_major: 7,
+        os_minor: 0,
+        count: 2,
+        os_lifecycle: 'retired',
+        application_stream_name: 'retired-stream',
+        rolling: false,
+        related: false,
+        systems_detail: [],
+      },
+      {
+        name: 'warning-stream',
+        display_name: 'Warning Stream',
+        start_date: '2023-01-01',
+        end_date: '2024-06-01',
+        support_status: 'support_ending_soon',
+        os_major: 8,
+        os_minor: 5,
+        count: 10,
+        os_lifecycle: 'active',
+        application_stream_name: 'warning-stream',
+        rolling: false,
+        related: false,
+        systems_detail: [],
+      },
+    ];
+
+    render(<LifecycleChart lifecycleData={mixedData} />);
     expect(screen.getByTestId('chart')).toBeInTheDocument();
   });
 });

--- a/src/Components/LifecycleChart/LifecycleChart.tsx
+++ b/src/Components/LifecycleChart/LifecycleChart.tsx
@@ -38,7 +38,7 @@ const LifecycleChart: React.FC<LifecycleChartProps> = ({ lifecycleData, viewFilt
   });
 
   // Bar tooltip state
-  const [tooltipData, setTooltipData] = React.useState<any>(null);
+  const [tooltipData, setTooltipData] = React.useState<ChartDataObject | null>(null);
   const [showTooltip, setShowTooltip] = React.useState<boolean>(false);
   const [tooltipPosition, setTooltipPosition] = React.useState({ x: 0, y: 0 });
 
@@ -324,8 +324,8 @@ const LifecycleChart: React.FC<LifecycleChartProps> = ({ lifecycleData, viewFilt
 Release: ${tooltipData.version}
 Support Type: ${tooltipData.packageType}
 Systems: ${tooltipData.numSystems}
-Start: ${formatDate(tooltipData.y0)}
-End: ${formatDate(tooltipData.y)}`;
+Start: ${formatDate(tooltipData.y0.toISOString())}
+End: ${formatDate(tooltipData.y.toISOString())}`;
 
     return (
       <div

--- a/src/Components/LifecycleChart/LifecycleChart.tsx
+++ b/src/Components/LifecycleChart/LifecycleChart.tsx
@@ -333,14 +333,14 @@ End: ${formatDate(tooltipData.y)}`;
           position: 'absolute',
           left: `${tooltipPosition.x}px`,
           top: `${tooltipPosition.y}px`,
-          backgroundColor: 'black',
-          color: 'white',
+          backgroundColor: 'var(--pf-t--global--background--color--floating--default)',
+          color: 'var(--pf-t--global--text--color--regular)',
           padding: '10px',
           borderRadius: '5px',
           zIndex: 1000,
           pointerEvents: 'none',
           whiteSpace: 'pre-line',
-          border: '1px solid #888',
+          border: '1px solid var(--pf-t--global--border--color--default)',
           maxWidth: '250px',
           fontSize: '14px',
           lineHeight: '1.5',
@@ -357,7 +357,7 @@ End: ${formatDate(tooltipData.y)}`;
             transform: 'translateY(-50%)',
             borderTop: '10px solid transparent',
             borderBottom: '10px solid transparent',
-            borderRight: '10px solid black',
+            borderRight: '10px solid var(--pf-t--global--background--color--floating--default)',
           }}
         />
         {content}
@@ -379,14 +379,14 @@ End: ${formatDate(tooltipData.y)}`;
           position: 'fixed',
           left: `${mousePosition.x + xOffset}px`,
           top: `${mousePosition.y + yOffset}px`,
-          backgroundColor: 'black',
-          color: 'white',
+          backgroundColor: 'var(--pf-t--global--background--color--floating--default)',
+          color: 'var(--pf-t--global--text--color--regular)',
           padding: '10px',
           borderRadius: '5px',
           zIndex: 1000,
           pointerEvents: 'none',
           whiteSpace: 'pre-line',
-          border: '1px solid #888',
+          border: '1px solid var(--pf-t--global--border--color--default)',
           maxWidth: '250px',
           fontSize: '14px',
           lineHeight: '1.5',
@@ -402,7 +402,7 @@ End: ${formatDate(tooltipData.y)}`;
             transform: 'translateY(-50%)',
             borderTop: '10px solid transparent',
             borderBottom: '10px solid transparent',
-            borderRight: '10px solid black',
+            borderRight: '10px solid var(--pf-t--global--background--color--floating--default)',
           }}
         />
         Current Date: {new Date().toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' })}
@@ -590,6 +590,11 @@ End: ${formatDate(tooltipData.y)}`;
             data={getLegendData()}
             height={50}
             gutter={20}
+            style={{
+              labels: {
+                fill: 'var(--pf-t--global--text--color--regular)',
+              },
+            }}
           />
         }
         legendPosition="bottom-left"
@@ -611,6 +616,17 @@ End: ${formatDate(tooltipData.y)}`;
             showGrid
             tickValues={yearTickValues}
             tickFormat={(t: Date) => t.toLocaleDateString('en-US', { year: 'numeric' })}
+            style={{
+              tickLabels: {
+                fill: 'var(--pf-t--global--text--color--regular)',
+              },
+              axisLabel: {
+                fill: 'var(--pf-t--global--text--color--regular)',
+              },
+              grid: {
+                stroke: 'var(--pf-t--global--border--color--default)',
+              },
+            }}
           />
         )}
         {/*X axis with date timeline for the top of the chart */}
@@ -621,6 +637,11 @@ End: ${formatDate(tooltipData.y)}`;
             orientation="top"
             tickValues={yearTickValues}
             tickFormat={(t: Date) => t.toLocaleDateString('en-US', { year: 'numeric' })}
+            style={{
+              tickLabels: {
+                fill: 'var(--pf-t--global--text--color--regular)',
+              },
+            }}
           />
         )}
         {/*Y axis with the name of each stream/operating system */}
@@ -630,6 +651,13 @@ End: ${formatDate(tooltipData.y)}`;
           style={{
             tickLabels: {
               fontSize: () => Math.max(10, Math.min(14, chartDimensions.width / 60)),
+              fill: 'var(--pf-t--global--text--color--regular)',
+            },
+            axisLabel: {
+              fill: 'var(--pf-t--global--text--color--regular)',
+            },
+            grid: {
+              stroke: 'var(--pf-t--global--border--color--default)',
             },
           }}
         />

--- a/src/Components/LifecycleChart/LifecycleChart.tsx
+++ b/src/Components/LifecycleChart/LifecycleChart.tsx
@@ -347,17 +347,18 @@ End: ${formatDate(tooltipData.y)}`;
           transform: 'translate(10px, -50%)',
         }}
       >
+        {/* Pointer */}
         <div
           style={{
             position: 'absolute',
-            width: 0,
-            height: 0,
-            left: '-10px',
+            width: '8px',
+            height: '8px',
+            left: '-4px',
             top: '50%',
-            transform: 'translateY(-50%)',
-            borderTop: '10px solid transparent',
-            borderBottom: '10px solid transparent',
-            borderRight: '10px solid var(--pf-t--global--background--color--floating--default)',
+            transform: 'translateY(-50%) rotate(45deg)',
+            backgroundColor: 'var(--pf-t--global--background--color--floating--default)',
+            borderLeft: '1px solid var(--pf-t--global--border--color--default)',
+            borderBottom: '1px solid var(--pf-t--global--border--color--default)',
           }}
         />
         {content}
@@ -392,17 +393,18 @@ End: ${formatDate(tooltipData.y)}`;
           lineHeight: '1.5',
         }}
       >
+        {/* Pointer */}
         <div
           style={{
             position: 'absolute',
-            width: 0,
-            height: 0,
-            left: '-10px',
+            width: '8px',
+            height: '8px',
+            left: '-4px',
             top: '50%',
-            transform: 'translateY(-50%)',
-            borderTop: '10px solid transparent',
-            borderBottom: '10px solid transparent',
-            borderRight: '10px solid var(--pf-t--global--background--color--floating--default)',
+            transform: 'translateY(-50%) rotate(45deg)',
+            backgroundColor: 'var(--pf-t--global--background--color--floating--default)',
+            borderLeft: '1px solid var(--pf-t--global--border--color--default)',
+            borderBottom: '1px solid var(--pf-t--global--border--color--default)',
           }}
         />
         Current Date: {new Date().toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' })}
@@ -743,7 +745,7 @@ End: ${formatDate(tooltipData.y)}`;
             y0={() => Date.now()}
             style={{
               data: {
-                stroke: 'black',
+                stroke: 'var(--pf-t--global--text--color--regular)',
                 strokeWidth: 2,
               },
             }}
@@ -764,7 +766,7 @@ End: ${formatDate(tooltipData.y)}`;
 
                           return {
                             style: {
-                              stroke: 'black',
+                              stroke: 'var(--pf-t--global--text--color--regular)',
                               strokeWidth: 3,
                             },
                           };
@@ -782,7 +784,7 @@ End: ${formatDate(tooltipData.y)}`;
 
                           return {
                             style: {
-                              stroke: '#151515',
+                              stroke: 'var(--pf-t--global--text--color--regular)',
                               strokeWidth: 2,
                             },
                           };

--- a/src/Components/LifecycleChartSystem/LifecycleChartSystem.test.tsx
+++ b/src/Components/LifecycleChartSystem/LifecycleChartSystem.test.tsx
@@ -128,4 +128,59 @@ describe('LifecycleChartSystem', () => {
     // Should be called again with the re-render
     expect(mockUseChartDataAttributes.mock.calls.length).toBeGreaterThan(initialCallCount);
   });
+
+  it('should render tooltip when tooltip data is set', () => {
+    const { container } = render(<LifecycleChartSystem lifecycleData={mockLifecycleData} />);
+
+    // The chart container should be rendered
+    const chartContainer = container.querySelector('.drf-lifecycle__chart');
+    expect(chartContainer).toBeInTheDocument();
+  });
+
+  it('should handle data with Unknown dates', () => {
+    const dataWithUnknownDates: SystemLifecycleChanges[] = [
+      {
+        name: 'RHEL 9.0',
+        display_name: 'RHEL 9.0',
+        start_date: 'Unknown',
+        end_date: 'Unknown',
+        support_status: 'supported',
+        major: 9,
+        minor: 0,
+        count: 1,
+        lifecycle_type: 'standard',
+        related: false,
+        systems_detail: [],
+      },
+    ];
+
+    render(<LifecycleChartSystem lifecycleData={dataWithUnknownDates} />);
+    expect(screen.getByTestId('chart')).toBeInTheDocument();
+  });
+
+  it('should render ChartLine component for current date indicator', () => {
+    render(<LifecycleChartSystem lifecycleData={mockLifecycleData} />);
+    expect(screen.getByTestId('chart-line')).toBeInTheDocument();
+  });
+
+  it('should handle null dates in data', () => {
+    const dataWithNullDates = [
+      {
+        name: 'RHEL 9.0',
+        display_name: 'RHEL 9.0',
+        start_date: null as unknown as string,
+        end_date: null as unknown as string,
+        support_status: 'supported',
+        major: 9,
+        minor: 0,
+        count: 1,
+        lifecycle_type: 'standard',
+        related: false,
+        systems_detail: [],
+      },
+    ] as SystemLifecycleChanges[];
+
+    render(<LifecycleChartSystem lifecycleData={dataWithNullDates} />);
+    expect(screen.getByTestId('chart')).toBeInTheDocument();
+  });
 });

--- a/src/Components/LifecycleChartSystem/LifecycleChartSystem.test.tsx
+++ b/src/Components/LifecycleChartSystem/LifecycleChartSystem.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import LifecycleChartSystem from './LifecycleChartSystem';
 import { useChartDataAttributes } from '../../utils/utils';
 import { SystemLifecycleChanges } from '../../types/SystemLifecycleChanges';
@@ -181,6 +181,77 @@ describe('LifecycleChartSystem', () => {
     ] as SystemLifecycleChanges[];
 
     render(<LifecycleChartSystem lifecycleData={dataWithNullDates} />);
+    expect(screen.getByTestId('chart')).toBeInTheDocument();
+  });
+
+  it('should handle mouse events on chart container', () => {
+    const { container } = render(<LifecycleChartSystem lifecycleData={mockLifecycleData} />);
+    const chartContainer = container.querySelector('.drf-lifecycle__chart');
+
+    expect(chartContainer).toBeInTheDocument();
+
+    if (chartContainer) {
+      // Simulate mouse leave to test tooltip clearing
+      act(() => {
+        fireEvent.mouseLeave(chartContainer);
+      });
+      expect(chartContainer).toBeInTheDocument();
+    }
+  });
+
+  it('should track mouse position for tooltip rendering', () => {
+    render(<LifecycleChartSystem lifecycleData={mockLifecycleData} />);
+
+    // Simulate mouse move to update position tracking
+    act(() => {
+      fireEvent.mouseMove(window, { clientX: 100, clientY: 200 });
+    });
+
+    expect(screen.getByTestId('chart')).toBeInTheDocument();
+  });
+
+  it('should handle resize events', () => {
+    render(<LifecycleChartSystem lifecycleData={mockLifecycleData} />);
+
+    // Simulate window resize
+    act(() => {
+      fireEvent(window, new Event('resize'));
+    });
+
+    expect(screen.getByTestId('chart')).toBeInTheDocument();
+  });
+
+  it('should render with different support status types', () => {
+    const mixedData: SystemLifecycleChanges[] = [
+      {
+        name: 'RHEL 7.0',
+        display_name: 'RHEL 7.0',
+        start_date: '2019-01-01',
+        end_date: '2020-01-01',
+        support_status: 'retired',
+        major: 7,
+        minor: 0,
+        count: 2,
+        lifecycle_type: 'standard',
+        related: false,
+        systems_detail: [],
+      },
+      {
+        name: 'RHEL 8.5',
+        display_name: 'RHEL 8.5',
+        start_date: '2023-01-01',
+        end_date: '2024-06-01',
+        support_status: 'support_ending_soon',
+        major: 8,
+        minor: 5,
+        count: 10,
+        lifecycle_type: 'standard',
+        related: false,
+        systems_detail: [],
+      },
+    ];
+
+    render(<LifecycleChartSystem lifecycleData={mixedData} />);
     expect(screen.getByTestId('chart')).toBeInTheDocument();
   });
 });

--- a/src/Components/LifecycleChartSystem/LifecycleChartSystem.tsx
+++ b/src/Components/LifecycleChartSystem/LifecycleChartSystem.tsx
@@ -350,17 +350,18 @@ End: ${formatDate(tooltipData.y)}`;
           transform: 'translate(10px, -50%)',
         }}
       >
+        {/* Pointer */}
         <div
           style={{
             position: 'absolute',
-            width: 0,
-            height: 0,
-            left: '-10px',
+            width: '8px',
+            height: '8px',
+            left: '-4px',
             top: '50%',
-            transform: 'translateY(-50%)',
-            borderTop: '10px solid transparent',
-            borderBottom: '10px solid transparent',
-            borderRight: '10px solid var(--pf-t--global--background--color--floating--default)',
+            transform: 'translateY(-50%) rotate(45deg)',
+            backgroundColor: 'var(--pf-t--global--background--color--floating--default)',
+            borderLeft: '1px solid var(--pf-t--global--border--color--default)',
+            borderBottom: '1px solid var(--pf-t--global--border--color--default)',
           }}
         />
         {content}
@@ -395,17 +396,18 @@ End: ${formatDate(tooltipData.y)}`;
           lineHeight: '1.5',
         }}
       >
+        {/* Pointer */}
         <div
           style={{
             position: 'absolute',
-            width: 0,
-            height: 0,
-            left: '-10px',
+            width: '8px',
+            height: '8px',
+            left: '-4px',
             top: '50%',
-            transform: 'translateY(-50%)',
-            borderTop: '10px solid transparent',
-            borderBottom: '10px solid transparent',
-            borderRight: '10px solid var(--pf-t--global--background--color--floating--default)',
+            transform: 'translateY(-50%) rotate(45deg)',
+            backgroundColor: 'var(--pf-t--global--background--color--floating--default)',
+            borderLeft: '1px solid var(--pf-t--global--border--color--default)',
+            borderBottom: '1px solid var(--pf-t--global--border--color--default)',
           }}
         />
         Current Date: {new Date().toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' })}
@@ -746,7 +748,7 @@ End: ${formatDate(tooltipData.y)}`;
             y0={() => Date.now()}
             style={{
               data: {
-                stroke: 'black',
+                stroke: 'var(--pf-t--global--text--color--regular)',
                 strokeWidth: 2,
               },
             }}
@@ -767,7 +769,7 @@ End: ${formatDate(tooltipData.y)}`;
 
                           return {
                             style: {
-                              stroke: 'black',
+                              stroke: 'var(--pf-t--global--text--color--regular)',
                               strokeWidth: 3,
                             },
                           };
@@ -785,7 +787,7 @@ End: ${formatDate(tooltipData.y)}`;
 
                           return {
                             style: {
-                              stroke: '#151515',
+                              stroke: 'var(--pf-t--global--text--color--regular)',
                               strokeWidth: 2,
                             },
                           };

--- a/src/Components/LifecycleChartSystem/LifecycleChartSystem.tsx
+++ b/src/Components/LifecycleChartSystem/LifecycleChartSystem.tsx
@@ -336,14 +336,14 @@ End: ${formatDate(tooltipData.y)}`;
           position: 'absolute',
           left: `${tooltipPosition.x}px`,
           top: `${tooltipPosition.y}px`,
-          backgroundColor: 'black',
-          color: 'white',
+          backgroundColor: 'var(--pf-t--global--background--color--floating--default)',
+          color: 'var(--pf-t--global--text--color--regular)',
           padding: '10px',
           borderRadius: '5px',
           zIndex: 1000,
           pointerEvents: 'none',
           whiteSpace: 'pre-line',
-          border: '1px solid #888',
+          border: '1px solid var(--pf-t--global--border--color--default)',
           maxWidth: '250px',
           fontSize: '14px',
           lineHeight: '1.5',
@@ -360,7 +360,7 @@ End: ${formatDate(tooltipData.y)}`;
             transform: 'translateY(-50%)',
             borderTop: '10px solid transparent',
             borderBottom: '10px solid transparent',
-            borderRight: '10px solid black',
+            borderRight: '10px solid var(--pf-t--global--background--color--floating--default)',
           }}
         />
         {content}
@@ -382,14 +382,14 @@ End: ${formatDate(tooltipData.y)}`;
           position: 'fixed',
           left: `${mousePosition.x + xOffset}px`,
           top: `${mousePosition.y + yOffset}px`,
-          backgroundColor: 'black',
-          color: 'white',
+          backgroundColor: 'var(--pf-t--global--background--color--floating--default)',
+          color: 'var(--pf-t--global--text--color--regular)',
           padding: '10px',
           borderRadius: '5px',
           zIndex: 1000,
           pointerEvents: 'none',
           whiteSpace: 'pre-line',
-          border: '1px solid #888',
+          border: '1px solid var(--pf-t--global--border--color--default)',
           maxWidth: '250px',
           fontSize: '14px',
           lineHeight: '1.5',
@@ -405,7 +405,7 @@ End: ${formatDate(tooltipData.y)}`;
             transform: 'translateY(-50%)',
             borderTop: '10px solid transparent',
             borderBottom: '10px solid transparent',
-            borderRight: '10px solid black',
+            borderRight: '10px solid var(--pf-t--global--background--color--floating--default)',
           }}
         />
         Current Date: {new Date().toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' })}
@@ -593,6 +593,11 @@ End: ${formatDate(tooltipData.y)}`;
             data={getLegendData()}
             height={50}
             gutter={20}
+            style={{
+              labels: {
+                fill: 'var(--pf-t--global--text--color--regular)',
+              },
+            }}
           />
         }
         legendPosition="bottom-left"
@@ -614,6 +619,17 @@ End: ${formatDate(tooltipData.y)}`;
             showGrid
             tickValues={yearTickValues}
             tickFormat={(t: Date) => t.toLocaleDateString('en-US', { year: 'numeric' })}
+            style={{
+              tickLabels: {
+                fill: 'var(--pf-t--global--text--color--regular)',
+              },
+              axisLabel: {
+                fill: 'var(--pf-t--global--text--color--regular)',
+              },
+              grid: {
+                stroke: 'var(--pf-t--global--border--color--default)',
+              },
+            }}
           />
         )}
         {/*X axis with date timeline for the top of the chart */}
@@ -624,6 +640,11 @@ End: ${formatDate(tooltipData.y)}`;
             orientation="top"
             tickValues={yearTickValues}
             tickFormat={(t: Date) => t.toLocaleDateString('en-US', { year: 'numeric' })}
+            style={{
+              tickLabels: {
+                fill: 'var(--pf-t--global--text--color--regular)',
+              },
+            }}
           />
         )}
         {/*Y axis with the name of each stream/operating system */}
@@ -633,6 +654,13 @@ End: ${formatDate(tooltipData.y)}`;
           style={{
             tickLabels: {
               fontSize: () => Math.max(10, Math.min(14, chartDimensions.width / 60)),
+              fill: 'var(--pf-t--global--text--color--regular)',
+            },
+            axisLabel: {
+              fill: 'var(--pf-t--global--text--color--regular)',
+            },
+            grid: {
+              stroke: 'var(--pf-t--global--border--color--default)',
             },
           }}
         />

--- a/src/Components/LifecycleChartSystem/LifecycleChartSystem.tsx
+++ b/src/Components/LifecycleChartSystem/LifecycleChartSystem.tsx
@@ -41,7 +41,7 @@ const LifecycleChartSystem: React.FC<LifecycleChartProps> = ({
   });
 
   // Bar tooltip state
-  const [tooltipData, setTooltipData] = React.useState<any>(null);
+  const [tooltipData, setTooltipData] = React.useState<ChartDataObject | null>(null);
   const [showTooltip, setShowTooltip] = React.useState<boolean>(false);
   const [tooltipPosition, setTooltipPosition] = React.useState({ x: 0, y: 0 });
 
@@ -327,8 +327,8 @@ const LifecycleChartSystem: React.FC<LifecycleChartProps> = ({
 Release: ${tooltipData.version}
 Support Type: ${tooltipData.packageType}
 Systems: ${tooltipData.numSystems}
-Start: ${formatDate(tooltipData.y0)}
-End: ${formatDate(tooltipData.y)}`;
+Start: ${formatDate(tooltipData.y0.toISOString())}
+End: ${formatDate(tooltipData.y.toISOString())}`;
 
     return (
       <div

--- a/src/Components/LifecycleFilters/LifecycleFilters.scss
+++ b/src/Components/LifecycleFilters/LifecycleFilters.scss
@@ -21,7 +21,7 @@
   align-items: baseline;
 
   label {
-    color: #000;
+    color: var(--pf-t--global--text--color--regular);
     font-size: 16px;
     font-weight: 500;
     line-height: 24px;

--- a/src/Components/LifecycleFilters/LifecycleFilters.scss
+++ b/src/Components/LifecycleFilters/LifecycleFilters.scss
@@ -61,7 +61,6 @@
   padding-right: 8px;
 }
 
-
 /* Fix toggle group height consistency */
 .drf-lifecycle__toggle-group-fixed-height {
   display: flex;

--- a/src/Components/Released/released.scss
+++ b/src/Components/Released/released.scss
@@ -1,4 +1,4 @@
-@import "~@redhat-cloud-services/frontend-components-utilities/styles/variables";
+@import '~@redhat-cloud-services/frontend-components-utilities/styles/variables';
 
 .sample-component {
   font-size: $ins-fontSize;

--- a/src/Components/Released/released.scss
+++ b/src/Components/Released/released.scss
@@ -7,11 +7,11 @@
 }
 
 .non-relevant {
-  color: gray;
+  color: var(--pf-t--global--text--color--subtle);
 }
 
 .pf-v6-c-sidebar {
-  background-color: white;
+  background-color: var(--pf-t--global--background--color--primary--default);
 }
 
 .pf-v6-c-sidebar__main {

--- a/src/Components/ReleasedView/release-view.scss
+++ b/src/Components/ReleasedView/release-view.scss
@@ -1,3 +1,3 @@
 .pf-m-current {
-    all: unset
+  all: unset;
 }

--- a/src/Components/SampleComponent/sample-component.scss
+++ b/src/Components/SampleComponent/sample-component.scss
@@ -1,4 +1,4 @@
-@import "~@redhat-cloud-services/frontend-components-utilities/styles/variables";
+@import '~@redhat-cloud-services/frontend-components-utilities/styles/variables';
 
 .sample-component {
   font-size: $ins-fontSize;

--- a/src/Components/UpcomingTable/upcoming-table.scss
+++ b/src/Components/UpcomingTable/upcoming-table.scss
@@ -11,7 +11,7 @@
   padding-left: 16px;
 
   label {
-    color: #000;
+    color: var(--pf-t--global--text--color--regular);
     font-size: 16px;
     font-weight: 500;
     line-height: 24px;

--- a/src/Routes/LifecyclePage/LifecyclePage.scss
+++ b/src/Routes/LifecyclePage/LifecyclePage.scss
@@ -1,3 +1,3 @@
 .pf-c-page__main-section {
-    margin-top: 0;
+  margin-top: 0;
 }

--- a/src/Routes/UpcomingPage/UpcomingPage.scss
+++ b/src/Routes/UpcomingPage/UpcomingPage.scss
@@ -1,3 +1,3 @@
 .pf-c-page__main-section {
-    margin-top: 0;
+  margin-top: 0;
 }

--- a/src/Routes/UpcomingPage/UpcomingPage.tsx
+++ b/src/Routes/UpcomingPage/UpcomingPage.tsx
@@ -30,11 +30,7 @@ const UpcomingPage = () => {
         <div style={{ display: 'flex', alignItems: 'center', gap: '0px' }}>
           <PageHeaderTitle title="Roadmap" />
           <Popover headerContent="About roadmap" bodyContent={popoverContent} position="right">
-            <Button
-              icon={<OutlinedQuestionCircleIcon />}
-              variant="plain"
-              aria-label="Roadmap information"
-            />
+            <Button icon={<OutlinedQuestionCircleIcon />} variant="plain" aria-label="Roadmap information" />
           </Popover>
         </div>
       </PageHeader>

--- a/src/Routes/UpcomingPage/UpcomingPage.tsx
+++ b/src/Routes/UpcomingPage/UpcomingPage.tsx
@@ -31,7 +31,7 @@ const UpcomingPage = () => {
           <PageHeaderTitle title="Roadmap" />
           <Popover headerContent="About roadmap" bodyContent={popoverContent} position="right">
             <Button
-              icon={<OutlinedQuestionCircleIcon style={{ color: '#6a6e73' }} />}
+              icon={<OutlinedQuestionCircleIcon />}
               variant="plain"
               aria-label="Roadmap information"
             />

--- a/src/index.html
+++ b/src/index.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html lang="en-US">
-    <head>
-        <meta charset="UTF-8">
-        <title>Starter App</title>
-        <esi:include src="/@@env/chrome/snippets/head.html"/>
-    </head>
-    <body>
-        <esi:include src="/@@env/chrome/snippets/body.html"/>
-    </body>
+  <head>
+    <meta charset="UTF-8" />
+    <title>Starter App</title>
+    <esi:include src="/@@env/chrome/snippets/head.html" />
+  </head>
+  <body>
+    <esi:include src="/@@env/chrome/snippets/body.html" />
+  </body>
 </html>


### PR DESCRIPTION
All components now use PatternFly v6's semantic color tokens:

✅ Text colors adapt to light/dark backgrounds
✅ Chart tooltips have theme-aware backgrounds and borders
✅ Current date line changes color based on theme
✅ Sidebar backgrounds match the theme
✅ Labels and headings are visible in both modes
The app will automatically respond to:

System-level dark mode preferences (prefers-color-scheme: dark)
Red Hat Cloud Services chrome theme settings

---

### Screenshots
<!-- Before and after proposed changes is ideal -->
<!-- Any key UI permutations should be captured -->
<!-- Draw attention to the area of UI that has changed -->
#### Before:
<img width="1641" height="949" alt="image" src="https://github.com/user-attachments/assets/dfe2724a-14d6-4a39-80ff-37ad92f0cd5c" />

<img width="1641" height="949" alt="image" src="https://github.com/user-attachments/assets/1c232fbf-a5cf-42d2-9a00-cacc76291f03" />


#### After:
<img width="1641" height="949" alt="Screenshot From 2026-04-21 16-58-53" src="https://github.com/user-attachments/assets/b94a43d1-692f-4206-989a-d9693a876045" />

<img width="1641" height="949" alt="Screenshot From 2026-04-21 16-48-05" src="https://github.com/user-attachments/assets/37fdc45d-1e6e-4770-9e82-88b76a2aa2c1" />

---

### Checklist ☑️
- [ ] PR only fixes one issue or story <!-- open new PR for others -->
- [ ] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [ ] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [ ] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [ ] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##
