### PR TITLE
[RHIENG-27888] Use deployedDate field

### DIFF
--- a/src/Components/Upcoming/Upcoming.test.tsx
+++ b/src/Components/Upcoming/Upcoming.test.tsx
@@ -30,6 +30,9 @@ jest.mock('../UpcomingTable/UpcomingTable', () => {
     return (
       <div data-testid="upcoming-table">
         <div data-testid="table-data-count">{data.length}</div>
+        <div data-testid="table-deployed-dates">
+          {JSON.stringify(data.map((d: any) => d.details?.deployedDate ?? null))}
+        </div>
         <div data-testid="selected-view-filter">{selectedViewFilter}</div>
         <div data-testid="no-data-available">{noDataAvailable.toString()}</div>
         <button onClick={resetInitialFilters} data-testid="reset-filters">
@@ -662,6 +665,43 @@ describe('UpcomingTab', () => {
       expect(screen.getByText('Deprecations')).toBeInTheDocument();
       expect(screen.getByText('Changes')).toBeInTheDocument();
       expect(screen.getByText('Additions and enhancements')).toBeInTheDocument();
+    });
+
+    test('fills in todays date when deployedDate is null', async () => {
+      const todayStr = new Date().toLocaleDateString('en-CA');
+      const dataWithNullDeployedDate: UpcomingChanges[] = [
+        {
+          name: 'Null Date Item',
+          type: 'deprecation',
+          release: 'R1',
+          date: '2024-12-01',
+          package: 'ruby',
+          details: {
+            summary: 'Test summary',
+            architecture: 'x86_64',
+            potentiallyAffectedSystemsCount: 0,
+            potentiallyAffectedSystemsDetail: [],
+            trainingTicket: 'TEST-1',
+            deployedDate: null,
+            lastModified: '2024-01-01',
+            detailFormat: 0,
+          },
+        },
+      ];
+
+      mockGetAllUpcomingChanges.mockResolvedValue({ data: dataWithNullDeployedDate });
+      mockGetRelevantUpcomingChanges.mockResolvedValue({ data: dataWithNullDeployedDate });
+
+      await act(async () => {
+        renderComponent();
+      });
+
+      await waitFor(() => {
+        expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
+      });
+
+      const deployedDates = JSON.parse(screen.getByTestId('table-deployed-dates').textContent!);
+      expect(deployedDates).toEqual([todayStr]);
     });
   });
 

--- a/src/Components/Upcoming/Upcoming.tsx
+++ b/src/Components/Upcoming/Upcoming.tsx
@@ -127,6 +127,11 @@ const UpcomingTab: React.FC<React.PropsWithChildren> = () => {
 
   // Optimized function to fetch both API endpoints in parallel
   const fetchBothDataSources = async () => {
+    // Used when we don't have deployedDate available - basically when there are
+    // new items which weren't deployed to production. This is for easier testing on stage.
+    // en-CA locale formats as YYYY-MM-DD using local time (not UTC) - handles corner case with timezones
+    const todayStr = new Date().toLocaleDateString('en-CA');
+
     try {
       // Fetch both APIs in parallel
       const [allResponse, relevantResponse] = await Promise.allSettled([
@@ -141,6 +146,13 @@ const UpcomingTab: React.FC<React.PropsWithChildren> = () => {
         allData = allData.map((item) => ({
           ...item,
           type: capitalizeFirstLetter(item.type),
+          ...(item.details && {
+            details: {
+              ...item.details,
+              // when deployedDate is not available, use todays date for easier testing
+              deployedDate: item.details.deployedDate ?? todayStr,
+            },
+          }),
         }));
         setAllUpcomingChangesData(allData);
         setDataFetchStatus((prev) => ({ ...prev, all: true }));
@@ -156,6 +168,13 @@ const UpcomingTab: React.FC<React.PropsWithChildren> = () => {
         relevantData = relevantData.map((item) => ({
           ...item,
           type: capitalizeFirstLetter(item.type),
+          ...(item.details && {
+            details: {
+              ...item.details,
+              // when deployedDate is not available, use todays date for easier testing
+              deployedDate: item.details.deployedDate ?? todayStr,
+            },
+          }),
         }));
         setRelevantUpcomingChangesData(relevantData);
         setDataFetchStatus((prev) => ({ ...prev, relevant: true }));

--- a/src/Components/Upcoming/Upcoming.tsx
+++ b/src/Components/Upcoming/Upcoming.tsx
@@ -129,8 +129,11 @@ const UpcomingTab: React.FC<React.PropsWithChildren> = () => {
   const fetchBothDataSources = async () => {
     // Used when we don't have deployedDate available - basically when there are
     // new items which weren't deployed to production. This is for easier testing on stage.
-    // en-CA locale formats as YYYY-MM-DD using local time (not UTC) - handles corner case with timezones
-    const todayStr = new Date().toLocaleDateString('en-CA');
+    // Format as YYYY-MM-DD using local time (not UTC) - handles corner case with timezones.
+    const now = new Date();
+    const todayStr = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(
+      now.getDate()
+    ).padStart(2, '0')}`;
 
     try {
       // Fetch both APIs in parallel

--- a/src/Components/UpcomingRow/UpcomingRow.test.tsx
+++ b/src/Components/UpcomingRow/UpcomingRow.test.tsx
@@ -66,7 +66,7 @@ const repoWithDetails: UpcomingChanges = {
     // Use type assertion to bypass TypeScript error for now
     potentiallyAffectedSystemsDetail: ['system1.example.com', 'system2.example.com', 'system3.example.com'] as any,
     trainingTicket: 'RUBY-123',
-    dateAdded: '2024-01-15',
+    deployedDate: '2024-01-15',
     lastModified: '2024-02-01',
     detailFormat: 0,
     architecture: 'x86_64',

--- a/src/Components/UpcomingRow/UpcomingRow.tsx
+++ b/src/Components/UpcomingRow/UpcomingRow.tsx
@@ -112,7 +112,7 @@ export const TableRow: React.FunctionComponent<TableRowProps> = ({
             {repo.release}
           </Td>
           <Td dataLabel={columnNames.addedToRoadmap} modifier="truncate">
-            {repo.details?.dateAdded ?? ''}
+            {repo.details?.deployedDate ?? ''}
           </Td>
           <Td dataLabel={columnNames.date} modifier="truncate">
             {formatDate(repo.date)}

--- a/src/Components/UpcomingTable/UpcomingTable.tsx
+++ b/src/Components/UpcomingTable/UpcomingTable.tsx
@@ -33,7 +33,7 @@ interface UpcomingTableProps {
     summary: string;
     potentiallyAffectedSystems: number;
     trainingTicket: string;
-    dateAdded: string;
+    deployedDate: string | null;
     lastModified: string;
     detailFormat: 0 | 1 | 2 | 3;
   };
@@ -106,7 +106,7 @@ export const UpcomingTable: React.FunctionComponent<UpcomingTableProps> = ({
 
   const getSortableRowValues = (repo: UpcomingChanges): (string | number)[] => {
     const { name, type, release, date } = repo;
-    const addedToRoadmap = repo.details?.dateAdded ?? '';
+    const addedToRoadmap = repo.details?.deployedDate ?? '';
     return [name, type, release, addedToRoadmap, date];
   };
 
@@ -206,7 +206,9 @@ export const UpcomingTable: React.FunctionComponent<UpcomingTableProps> = ({
   const isDateInRange = (dateString: string | undefined, rangeType: string): boolean => {
     if (!dateString) return false;
 
-    const date = new Date(dateString);
+    // Append T00:00:00 to parse as local time — without it, "YYYY-MM-DD" is parsed
+    // as UTC midnight which breaks comparisons against local-time "today"
+    const date = new Date(dateString + 'T00:00:00');
     const today = new Date();
     today.setHours(0, 0, 0, 0);
 
@@ -257,7 +259,8 @@ export const UpcomingTable: React.FunctionComponent<UpcomingTableProps> = ({
 
     // Search added to roadmap with date range
     const matchesAddedToRoadmapValue =
-      addedToRoadmapSelection === '' || isDateInRange(repo.details?.dateAdded, addedToRoadmapSelection);
+      addedToRoadmapSelection === '' ||
+      isDateInRange(repo.details?.deployedDate ?? undefined, addedToRoadmapSelection);
 
     return (
       (searchValue === '' || matchesNameValue) &&

--- a/src/Components/UpcomingTable/UpcomingTable.tsx
+++ b/src/Components/UpcomingTable/UpcomingTable.tsx
@@ -206,11 +206,13 @@ export const UpcomingTable: React.FunctionComponent<UpcomingTableProps> = ({
   const isDateInRange = (dateString: string | undefined, rangeType: string): boolean => {
     if (!dateString) return false;
 
-    // Append T00:00:00 to parse as local time — without it, "YYYY-MM-DD" is parsed
-    // as UTC midnight which breaks comparisons against local-time "today"
-    const date = new Date(dateString + 'T00:00:00');
-    const today = new Date();
-    today.setHours(0, 0, 0, 0);
+    // Normalize the target date: Force to local midnight to avoid time drift
+    // Once year, month and day is set, time is the default local midnight
+    const [year, month, day] = dateString.split('-').map(Number);
+    const date = new Date(year, month - 1, day); // months are zero-indexed.
+    // Define "today" normalized to midnight
+    const now = new Date();
+    const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
 
     switch (rangeType) {
       case 'lastMonthToDate': {

--- a/src/types/UpcomingChanges.ts
+++ b/src/types/UpcomingChanges.ts
@@ -12,7 +12,7 @@ export type UpcomingChanges = {
     potentiallyAffectedSystemsCount: number;
     potentiallyAffectedSystemsDetail: SystemsDetail[];
     trainingTicket: string;
-    dateAdded: string;
+    deployedDate: string | null;
     lastModified: string;
     detailFormat: 0 | 1 | 2 | 3;
   };


### PR DESCRIPTION
* Use deployedDate filed as value for "Added to Roadmap" which is newly added field needed for roadmap notifications. It marks when item was deployed to production.
* Fix of bug with timezones - item which was added today was missing when filter "Added to roadmap" - "Last month to date" applied
* When deployedDate is null, use today's date instead. This can happen when there are new items which weren't yet deployed to production.

### Description
<!-- Must include 2-3 sentence summary of proposed changes -->
<!-- Must include links to impacted UI(s) or information regarding the impacted UI -->
<!-- Must include any relevant steps to reproduce (if not clear in tracked issue or story) -->
<!-- Must include RSPEED-XXX link (if proposed change involves tracked issue or story) -->
description text...

Jira link:
[RSPEED-XXX](https://redhat.atlassian.net/browse/RSPEED-XXX)

---

### Screenshots
<!-- Before and after proposed changes is ideal -->
<!-- Any key UI permutations should be captured -->
<!-- Draw attention to the area of UI that has changed -->
#### Before:


#### After:


---

### Checklist ☑️
- [ ] PR only fixes one issue or story <!-- open new PR for others -->
- [ ] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [ ] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [ ] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [ ] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##
