### PR TITLE
[RHINENG-27229] Add multi-format export dropdown with flat host-level data

### DIFF
--- a/src/Components/ExportDataButton/ExportDataButton.tsx
+++ b/src/Components/ExportDataButton/ExportDataButton.tsx
@@ -1,36 +1,69 @@
 import React from 'react';
-import { Button, Tooltip } from '@patternfly/react-core';
+import { Dropdown, DropdownItem, DropdownList, MenuToggle, Tooltip } from '@patternfly/react-core';
 import ExportIcon from '@patternfly/react-icons/dist/esm/icons/export-icon';
 
+export type ExportFormat = 'csv' | 'json' | 'xml';
+
 interface ExportDataButtonProps {
-  onClick: () => void;
+  onExport: (format: ExportFormat) => void;
   isDisabled?: boolean;
   tooltipContent?: string;
   disabledTooltipContent?: string;
-  ariaLabel?: string;
   className?: string;
 }
 
 const ExportDataButton: React.FunctionComponent<ExportDataButtonProps> = ({
-  onClick,
+  onExport,
   isDisabled = false,
   tooltipContent = 'Export data',
   disabledTooltipContent,
-  ariaLabel = 'Download visible dataset as CSV',
   className,
 }) => {
+  const [isOpen, setIsOpen] = React.useState(false);
+
   const content = isDisabled && disabledTooltipContent ? disabledTooltipContent : tooltipContent;
+
+  const onSelect = (_event: React.MouseEvent | undefined, value: string | number | undefined) => {
+    setIsOpen(false);
+    if (value) {
+      onExport(value as ExportFormat);
+    }
+  };
 
   return (
     <Tooltip content={content}>
-      <Button
-        className={className}
-        variant="plain"
-        aria-label={ariaLabel}
-        onClick={onClick}
-        isDisabled={isDisabled}
-        icon={<ExportIcon />}
-      ></Button>
+      <Dropdown
+        isOpen={isOpen}
+        onSelect={onSelect}
+        onOpenChange={setIsOpen}
+        toggle={(toggleRef: React.Ref<HTMLDivElement>) => (
+          <MenuToggle
+            ref={toggleRef}
+            className={className}
+            variant="plain"
+            onClick={() => setIsOpen((prev) => !prev)}
+            isExpanded={isOpen}
+            isDisabled={isDisabled}
+            aria-label="Export host list"
+          >
+            <ExportIcon />
+          </MenuToggle>
+        )}
+        popperProps={{ enableFlip: true, position: 'start' }}
+        shouldFocusToggleOnSelect
+      >
+        <DropdownList>
+          <DropdownItem value="csv" key="csv">
+            Export host list to CSV
+          </DropdownItem>
+          <DropdownItem value="json" key="json">
+            Export host list to JSON
+          </DropdownItem>
+          <DropdownItem value="xml" key="xml">
+            Export host list to XML
+          </DropdownItem>
+        </DropdownList>
+      </Dropdown>
     </Tooltip>
   );
 };

--- a/src/Components/Lifecycle/Lifecycle.test.tsx
+++ b/src/Components/Lifecycle/Lifecycle.test.tsx
@@ -50,7 +50,7 @@ jest.mock('../../Components/LifecycleFilters/LifecycleFilters', () => {
     onLifecycleDropdownSelect,
     selectedChartSortBy = 'Retirement date', // Default value
     updateChartSortValue,
-    downloadCSV,
+    onExport,
     selectedViewFilter = 'installed-only', // Default value
     handleViewFilterChange,
     noDataAvailable,
@@ -91,8 +91,14 @@ jest.mock('../../Components/LifecycleFilters/LifecycleFilters', () => {
         <option value="installed-only">Installed Only</option>
         <option value="installed-and-related">Installed and Related</option>
       </select>
-      <button data-testid="download-csv" onClick={downloadCSV}>
-        Download CSV
+      <button data-testid="export-csv" onClick={() => onExport?.('csv')}>
+        Export CSV
+      </button>
+      <button data-testid="export-json" onClick={() => onExport?.('json')}>
+        Export JSON
+      </button>
+      <button data-testid="export-xml" onClick={() => onExport?.('xml')}>
+        Export XML
       </button>
 
       <ul data-testid="rhel-version-options">
@@ -154,6 +160,10 @@ jest.mock('export-to-csv', () => ({
   generateCsv: jest.fn(() => () => 'csv,data'),
   download: jest.fn(() => () => {}),
 }));
+
+// Mock URL.createObjectURL for JSON/XML export tests
+URL.createObjectURL = jest.fn(() => 'blob:mock-url');
+URL.revokeObjectURL = jest.fn();
 
 // Test data
 const mockSystemData: SystemLifecycleChanges[] = [
@@ -478,21 +488,50 @@ describe('LifecycleTab Component', () => {
     });
   });
 
-  describe('CSV Download', () => {
-    test('downloads CSV when button is clicked', async () => {
+  describe('Data Export', () => {
+    test('exports CSV when button is clicked', async () => {
       renderWithRouter(<LifecycleTab />);
 
       await waitFor(() => {
         expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
       });
 
-      const downloadButton = screen.getByTestId('download-csv');
+      const exportButton = screen.getByTestId('export-csv');
       await act(async () => {
-        fireEvent.click(downloadButton);
+        fireEvent.click(exportButton);
       });
 
-      // Verify that the download function was called
-      expect(downloadButton).toBeInTheDocument();
+      expect(exportButton).toBeInTheDocument();
+    });
+
+    test('exports JSON when button is clicked', async () => {
+      renderWithRouter(<LifecycleTab />);
+
+      await waitFor(() => {
+        expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
+      });
+
+      const exportButton = screen.getByTestId('export-json');
+      await act(async () => {
+        fireEvent.click(exportButton);
+      });
+
+      expect(exportButton).toBeInTheDocument();
+    });
+
+    test('exports XML when button is clicked', async () => {
+      renderWithRouter(<LifecycleTab />);
+
+      await waitFor(() => {
+        expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
+      });
+
+      const exportButton = screen.getByTestId('export-xml');
+      await act(async () => {
+        fireEvent.click(exportButton);
+      });
+
+      expect(exportButton).toBeInTheDocument();
     });
   });
 

--- a/src/Components/Lifecycle/Lifecycle.test.tsx
+++ b/src/Components/Lifecycle/Lifecycle.test.tsx
@@ -129,6 +129,7 @@ jest.mock('../../Components/LifecycleTable/LifecycleTable', () => {
 
 // Mock utils
 jest.mock('../../utils/utils', () => ({
+  buildExportData: jest.fn(() => [{ appstream_module: 'test', release: 9 }]),
   buildURL: jest.fn((filters) => {
     const params = new URLSearchParams();
     Object.entries(filters).forEach(([key, value]) => {
@@ -146,6 +147,7 @@ jest.mock('./filteringUtils', () => ({
   DEFAULT_CHART_SORTBY_VALUE: 'Retirement date',
   DEFAULT_DROPDOWN_VALUE: 'rhel-9-appstreams',
   RHEL_8_STREAMS_DROPDOWN_VALUE: 'rhel-8-appstreams',
+  RHEL_10_STREAMS_DROPDOWN_VALUE: 'rhel-10-appstreams',
   RHEL_SYSTEMS_DROPDOWN_VALUE: 'rhel-systems',
   filterChartDataByName: jest.fn((data) => data.sort((a: any, b: any) => a.name?.localeCompare(b.name))),
   filterChartDataByRelease: jest.fn((data) => data),
@@ -154,16 +156,11 @@ jest.mock('./filteringUtils', () => ({
   filterChartDataBySystems: jest.fn((data) => data),
 }));
 
-// Mock export-to-csv
-jest.mock('export-to-csv', () => ({
-  mkConfig: jest.fn(() => ({})),
-  generateCsv: jest.fn(() => () => 'csv,data'),
-  download: jest.fn(() => () => {}),
+// Mock shared export utility
+const mockExportData = jest.fn();
+jest.mock('../../utils/export', () => ({
+  exportData: (...args: any[]) => mockExportData(...args),
 }));
-
-// Mock URL.createObjectURL for JSON/XML export tests
-URL.createObjectURL = jest.fn(() => 'blob:mock-url');
-URL.revokeObjectURL = jest.fn();
 
 // Test data
 const mockSystemData: SystemLifecycleChanges[] = [
@@ -489,6 +486,10 @@ describe('LifecycleTab Component', () => {
   });
 
   describe('Data Export', () => {
+    beforeEach(() => {
+      mockExportData.mockClear();
+    });
+
     test('exports CSV when button is clicked', async () => {
       renderWithRouter(<LifecycleTab />);
 
@@ -496,12 +497,11 @@ describe('LifecycleTab Component', () => {
         expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
       });
 
-      const exportButton = screen.getByTestId('export-csv');
       await act(async () => {
-        fireEvent.click(exportButton);
+        fireEvent.click(screen.getByTestId('export-csv'));
       });
 
-      expect(exportButton).toBeInTheDocument();
+      expect(mockExportData).toHaveBeenCalledWith('csv', expect.any(Array));
     });
 
     test('exports JSON when button is clicked', async () => {
@@ -511,12 +511,11 @@ describe('LifecycleTab Component', () => {
         expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
       });
 
-      const exportButton = screen.getByTestId('export-json');
       await act(async () => {
-        fireEvent.click(exportButton);
+        fireEvent.click(screen.getByTestId('export-json'));
       });
 
-      expect(exportButton).toBeInTheDocument();
+      expect(mockExportData).toHaveBeenCalledWith('json', expect.any(Array));
     });
 
     test('exports XML when button is clicked', async () => {
@@ -526,12 +525,11 @@ describe('LifecycleTab Component', () => {
         expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
       });
 
-      const exportButton = screen.getByTestId('export-xml');
       await act(async () => {
-        fireEvent.click(exportButton);
+        fireEvent.click(screen.getByTestId('export-xml'));
       });
 
-      expect(exportButton).toBeInTheDocument();
+      expect(mockExportData).toHaveBeenCalledWith('xml', expect.any(Array));
     });
   });
 

--- a/src/Components/Lifecycle/Lifecycle.tsx
+++ b/src/Components/Lifecycle/Lifecycle.tsx
@@ -25,7 +25,7 @@ import {
 import { SystemLifecycleChanges } from '../../types/SystemLifecycleChanges';
 import { Stream } from '../../types/Stream';
 import { useSearchParams } from 'react-router-dom';
-import { buildURL, checkValidityOfQueryParam } from '../../utils/utils';
+import { buildExportData, buildURL, checkValidityOfQueryParam } from '../../utils/utils';
 import {
   DEFAULT_CHART_SORTBY_VALUE,
   DEFAULT_DROPDOWN_VALUE,
@@ -42,10 +42,9 @@ const LifecycleChart = lazy(() => import('../../Components/LifecycleChart/Lifecy
 const LifecycleChartSystem = lazy(() => import('../../Components/LifecycleChartSystem/LifecycleChartSystem'));
 const LifecycleFilters = lazy(() => import('../../Components/LifecycleFilters/LifecycleFilters'));
 const LifecycleTable = lazy(() => import('../../Components/LifecycleTable/LifecycleTable'));
-import { download, generateCsv, mkConfig } from 'export-to-csv';
-import { ExportFormat } from '../ExportDataButton/ExportDataButton';
+import { exportData as exportToFile } from '../../utils/export';
 import ErrorState from '@patternfly/react-component-groups/dist/dynamic/ErrorState';
-import { formatDate, getNewName } from '../../utils/utils';
+import { getNewName } from '../../utils/utils';
 import { ExtendedFilter } from '../../types/Filter';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 
@@ -96,8 +95,6 @@ const LifecycleTab: React.FC<React.PropsWithChildren> = () => {
   const [appsSwitchKey, setAppsSwitchKey] = useState(0);
 
   const [disableInstalledOnly, setDisableInstalledOnly] = useState<boolean>(false);
-
-  const csvConfig = mkConfig({ useKeysAsHeaders: true });
 
   const isAppStream = (v: string) =>
     v === DEFAULT_DROPDOWN_VALUE || v === RHEL_8_STREAMS_DROPDOWN_VALUE || v === RHEL_10_STREAMS_DROPDOWN_VALUE;
@@ -1008,110 +1005,15 @@ const LifecycleTab: React.FC<React.PropsWithChildren> = () => {
     return data;
   };
 
-  const buildExportData = () => {
-    const data: { [key: string]: string | number }[] = [];
-    if (
-      lifecycleDropdownValue === DEFAULT_DROPDOWN_VALUE ||
-      lifecycleDropdownValue === RHEL_8_STREAMS_DROPDOWN_VALUE ||
-      lifecycleDropdownValue === RHEL_10_STREAMS_DROPDOWN_VALUE
-    ) {
-      (filteredTableData as Stream[]).forEach((stream: Stream) => {
-        const hosts = stream.systems_detail ?? [];
-        if (hosts.length > 0) {
-          hosts.forEach((host, index) => {
-            data.push({
-              appstream_module: stream.display_name,
-              hostname: host.display_name,
-              host_id: host.id,
-              release: stream.os_major,
-              release_date: formatDate(stream.start_date),
-              retirement_date: formatDate(stream.end_date),
-              lifecycle_status: stream.support_status,
-              rhel_version: `${stream.os_major}.${stream.os_minor}`,
-              system_index: `${index + 1} of ${stream.count}`,
-            });
-          });
-        } else {
-          data.push({
-            appstream_module: stream.display_name,
-            release: stream.os_major,
-            release_date: formatDate(stream.start_date),
-            retirement_date: formatDate(stream.end_date),
-            lifecycle_status: stream.support_status,
-            rhel_version: `${stream.os_major}.${stream.os_minor}`,
-          });
-        }
-      });
-    } else if (lifecycleDropdownValue === RHEL_SYSTEMS_DROPDOWN_VALUE) {
-      (filteredTableData as SystemLifecycleChanges[]).forEach((item: SystemLifecycleChanges) => {
-        const hosts = item.systems_detail ?? [];
-        if (hosts.length > 0) {
-          hosts.forEach((host, index) => {
-            data.push({
-              hostname: host.display_name,
-              host_id: host.id,
-              release: item.name,
-              release_date: formatDate(item.start_date),
-              retirement_date: formatDate(item.end_date),
-              lifecycle_status: item.support_status,
-              rhel_version: `${item.major}.${item.minor}`,
-              system_index: `${index + 1} of ${item.count}`,
-            });
-          });
-        } else {
-          data.push({
-            release: item.name,
-            release_date: formatDate(item.start_date),
-            retirement_date: formatDate(item.end_date),
-            lifecycle_status: item.support_status,
-            rhel_version: `${item.major}.${item.minor}`,
-          });
-        }
-      });
-    }
-    return data;
-  };
+  const appStreamDropdownValues = [
+    DEFAULT_DROPDOWN_VALUE,
+    RHEL_8_STREAMS_DROPDOWN_VALUE,
+    RHEL_10_STREAMS_DROPDOWN_VALUE,
+  ];
 
-  const downloadFile = (content: string, filename: string, mimeType: string) => {
-    const blob = new Blob([content], { type: mimeType });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = filename;
-    a.click();
-    URL.revokeObjectURL(url);
-  };
-
-  const exportData = (format: ExportFormat) => {
-    const data = buildExportData();
-
-    switch (format) {
-      case 'csv': {
-        const csv = generateCsv(csvConfig)(data);
-        download(csvConfig)(csv);
-        break;
-      }
-      case 'json': {
-        downloadFile(JSON.stringify(data, null, 2), 'export.json', 'application/json');
-        break;
-      }
-      case 'xml': {
-        const xmlRows = data
-          .map((row) => {
-            const fields = Object.entries(row)
-              .map(([key, value]) => {
-                const tag = key.replace(/\s+/g, '_');
-                return `      <${tag}>${value}</${tag}>`;
-              })
-              .join('\n');
-            return `    <row>\n${fields}\n    </row>`;
-          })
-          .join('\n');
-        const xml = `<?xml version="1.0" encoding="UTF-8"?>\n<data>\n${xmlRows}\n</data>`;
-        downloadFile(xml, 'export.xml', 'application/xml');
-        break;
-      }
-    }
+  const handleExport = (format: 'csv' | 'json' | 'xml') => {
+    const data = buildExportData(filteredTableData, lifecycleDropdownValue, appStreamDropdownValues);
+    exportToFile(format, data);
   };
 
   if (isLoading) {
@@ -1286,7 +1188,7 @@ const LifecycleTab: React.FC<React.PropsWithChildren> = () => {
             onLifecycleDropdownSelect={onLifecycleDropdownSelect}
             selectedChartSortBy={chartSortByValue}
             updateChartSortValue={setOrderingStates}
-            onExport={exportData}
+            onExport={handleExport}
             selectedViewFilter={selectedViewFilter}
             handleViewFilterChange={handleViewFilterChange}
             noDataAvailable={noDataAvailable}

--- a/src/Components/Lifecycle/Lifecycle.tsx
+++ b/src/Components/Lifecycle/Lifecycle.tsx
@@ -43,6 +43,7 @@ const LifecycleChartSystem = lazy(() => import('../../Components/LifecycleChartS
 const LifecycleFilters = lazy(() => import('../../Components/LifecycleFilters/LifecycleFilters'));
 const LifecycleTable = lazy(() => import('../../Components/LifecycleTable/LifecycleTable'));
 import { download, generateCsv, mkConfig } from 'export-to-csv';
+import { ExportFormat } from '../ExportDataButton/ExportDataButton';
 import ErrorState from '@patternfly/react-component-groups/dist/dynamic/ErrorState';
 import { formatDate, getNewName } from '../../utils/utils';
 import { ExtendedFilter } from '../../types/Filter';
@@ -1007,34 +1008,110 @@ const LifecycleTab: React.FC<React.PropsWithChildren> = () => {
     return data;
   };
 
-  const downloadCSV = () => {
+  const buildExportData = () => {
     const data: { [key: string]: string | number }[] = [];
     if (
       lifecycleDropdownValue === DEFAULT_DROPDOWN_VALUE ||
       lifecycleDropdownValue === RHEL_8_STREAMS_DROPDOWN_VALUE ||
       lifecycleDropdownValue === RHEL_10_STREAMS_DROPDOWN_VALUE
     ) {
-      (filteredTableData as Stream[]).forEach((item: Stream) =>
-        data.push({
-          Name: item.display_name,
-          Release: item.os_major,
-          'Release date': formatDate(item.start_date),
-          'Retirement date': formatDate(item.end_date),
-          Systems: item.count,
-        })
-      );
+      (filteredTableData as Stream[]).forEach((stream: Stream) => {
+        const hosts = stream.systems_detail ?? [];
+        if (hosts.length > 0) {
+          hosts.forEach((host, index) => {
+            data.push({
+              hostname: host.display_name,
+              host_id: host.id,
+              appstream_module: stream.display_name,
+              release: stream.os_major,
+              release_date: formatDate(stream.start_date),
+              retirement_date: formatDate(stream.end_date),
+              lifecycle_status: stream.support_status,
+              rhel_version: `${stream.os_major}.${stream.os_minor}`,
+              system_index: `${index + 1} of ${stream.count}`,
+            });
+          });
+        } else {
+          data.push({
+            appstream_module: stream.display_name,
+            release: stream.os_major,
+            release_date: formatDate(stream.start_date),
+            retirement_date: formatDate(stream.end_date),
+            lifecycle_status: stream.support_status,
+            rhel_version: `${stream.os_major}.${stream.os_minor}`,
+          });
+        }
+      });
     } else if (lifecycleDropdownValue === RHEL_SYSTEMS_DROPDOWN_VALUE) {
-      (filteredTableData as SystemLifecycleChanges[]).forEach((item: SystemLifecycleChanges) =>
-        data.push({
-          Name: item.name,
-          'Start date': formatDate(item.start_date),
-          'End date': formatDate(item.end_date),
-          Systems: item.count,
-        })
-      );
+      (filteredTableData as SystemLifecycleChanges[]).forEach((item: SystemLifecycleChanges) => {
+        const hosts = item.systems_detail ?? [];
+        if (hosts.length > 0) {
+          hosts.forEach((host, index) => {
+            data.push({
+              hostname: host.display_name,
+              host_id: host.id,
+              release: item.name,
+              release_date: formatDate(item.start_date),
+              retirement_date: formatDate(item.end_date),
+              lifecycle_status: item.support_status,
+              rhel_version: `${item.major}.${item.minor}`,
+              system_index: `${index + 1} of ${item.count}`,
+            });
+          });
+        } else {
+          data.push({
+            release: item.name,
+            release_date: formatDate(item.start_date),
+            retirement_date: formatDate(item.end_date),
+            lifecycle_status: item.support_status,
+            rhel_version: `${item.major}.${item.minor}`,
+          });
+        }
+      });
     }
-    const csv = generateCsv(csvConfig)(data);
-    download(csvConfig)(csv);
+    return data;
+  };
+
+  const downloadFile = (content: string, filename: string, mimeType: string) => {
+    const blob = new Blob([content], { type: mimeType });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = filename;
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const exportData = (format: ExportFormat) => {
+    const data = buildExportData();
+
+    switch (format) {
+      case 'csv': {
+        const csv = generateCsv(csvConfig)(data);
+        download(csvConfig)(csv);
+        break;
+      }
+      case 'json': {
+        downloadFile(JSON.stringify(data, null, 2), 'export.json', 'application/json');
+        break;
+      }
+      case 'xml': {
+        const xmlRows = data
+          .map((row) => {
+            const fields = Object.entries(row)
+              .map(([key, value]) => {
+                const tag = key.replace(/\s+/g, '_');
+                return `      <${tag}>${value}</${tag}>`;
+              })
+              .join('\n');
+            return `    <row>\n${fields}\n    </row>`;
+          })
+          .join('\n');
+        const xml = `<?xml version="1.0" encoding="UTF-8"?>\n<data>\n${xmlRows}\n</data>`;
+        downloadFile(xml, 'export.xml', 'application/xml');
+        break;
+      }
+    }
   };
 
   if (isLoading) {
@@ -1209,7 +1286,7 @@ const LifecycleTab: React.FC<React.PropsWithChildren> = () => {
             onLifecycleDropdownSelect={onLifecycleDropdownSelect}
             selectedChartSortBy={chartSortByValue}
             updateChartSortValue={setOrderingStates}
-            downloadCSV={downloadCSV}
+            onExport={exportData}
             selectedViewFilter={selectedViewFilter}
             handleViewFilterChange={handleViewFilterChange}
             noDataAvailable={noDataAvailable}

--- a/src/Components/Lifecycle/Lifecycle.tsx
+++ b/src/Components/Lifecycle/Lifecycle.tsx
@@ -1020,9 +1020,9 @@ const LifecycleTab: React.FC<React.PropsWithChildren> = () => {
         if (hosts.length > 0) {
           hosts.forEach((host, index) => {
             data.push({
+              appstream_module: stream.display_name,
               hostname: host.display_name,
               host_id: host.id,
-              appstream_module: stream.display_name,
               release: stream.os_major,
               release_date: formatDate(stream.start_date),
               retirement_date: formatDate(stream.end_date),

--- a/src/Components/LifecycleFilters/AppStreamsViewToolbar.test.tsx
+++ b/src/Components/LifecycleFilters/AppStreamsViewToolbar.test.tsx
@@ -35,7 +35,7 @@ describe('AppStreamsViewToolbar', () => {
     onToggleClick: jest.fn(),
     onSelect: jest.fn(),
     setIsOpen: jest.fn(),
-    downloadCSV: jest.fn(),
+    onExport: jest.fn(),
     disableInstalledOnly: false,
   };
 
@@ -260,19 +260,16 @@ describe('AppStreamsViewToolbar', () => {
     });
   });
 
-  describe('Download CSV Button', () => {
-    test('calls downloadCSV when download button is clicked', () => {
-      const downloadCSV = jest.fn();
-      render(<AppStreamsViewToolbar {...defaultProps} downloadCSV={downloadCSV} />);
+  describe('Export Button', () => {
+    test('renders successfully with onExport prop', () => {
+      render(<AppStreamsViewToolbar {...defaultProps} />);
 
-      // Component should render successfully with downloadCSV prop
       expect(screen.getByRole('button', { name: 'Installed and related' })).toBeInTheDocument();
     });
 
-    test('renders successfully with downloadCSV prop', () => {
+    test('renders all view filter buttons', () => {
       render(<AppStreamsViewToolbar {...defaultProps} />);
 
-      // Component should still render even when download is present
       expect(screen.getByRole('button', { name: 'All' })).toBeInTheDocument();
     });
   });

--- a/src/Components/LifecycleFilters/AppStreamsViewToolbar.tsx
+++ b/src/Components/LifecycleFilters/AppStreamsViewToolbar.tsx
@@ -20,7 +20,7 @@ import {
   Tooltip,
 } from '@patternfly/react-core';
 import { FilterIcon } from '@patternfly/react-icons';
-import ExportDataButton from '../ExportDataButton/ExportDataButton';
+import ExportDataButton, { ExportFormat } from '../ExportDataButton/ExportDataButton';
 
 const FIELD_OPTIONS = ['Name', 'Status'] as const;
 const DROPDOWN_ITEMS = ['Retirement date', 'Name', 'Release version', 'Release date', 'Systems'];
@@ -53,7 +53,7 @@ interface AppStreamsViewToolbarProps {
     value: string | number | undefined
   ) => void;
   setIsOpen: (open: boolean) => void;
-  downloadCSV: () => void;
+  onExport: (format: ExportFormat) => void;
   disableInstalledOnly: boolean;
 }
 
@@ -77,7 +77,7 @@ export const AppStreamsViewToolbar: React.FunctionComponent<AppStreamsViewToolba
   onToggleClick,
   onSelect,
   setIsOpen,
-  downloadCSV,
+  onExport,
   disableInstalledOnly,
 }) => {
   return (
@@ -184,7 +184,7 @@ export const AppStreamsViewToolbar: React.FunctionComponent<AppStreamsViewToolba
               </Form>
             </ToolbarItem>
             <ToolbarItem>
-              <ExportDataButton className="drf-lifecycle__filter-download" onClick={downloadCSV} />
+              <ExportDataButton className="drf-lifecycle__filter-download" onExport={onExport} />
             </ToolbarItem>
           </ToolbarGroup>
         </ToolbarContent>

--- a/src/Components/LifecycleFilters/LifecycleFilters.test.tsx
+++ b/src/Components/LifecycleFilters/LifecycleFilters.test.tsx
@@ -23,7 +23,7 @@ describe('LifecycleFilters', () => {
         onLifecycleDropdownSelect={jest.fn()}
         selectedChartSortBy="Retirement date"
         updateChartSortValue={jest.fn()}
-        downloadCSV={jest.fn()}
+        onExport={jest.fn()}
         selectedViewFilter="all"
         handleViewFilterChange={jest.fn()}
         noDataAvailable={false}
@@ -50,7 +50,7 @@ describe('LifecycleFilters', () => {
         onLifecycleDropdownSelect={jest.fn()}
         selectedChartSortBy="Retirement date"
         updateChartSortValue={jest.fn()}
-        downloadCSV={jest.fn()}
+        onExport={jest.fn()}
         selectedViewFilter="all"
         handleViewFilterChange={jest.fn()}
         noDataAvailable={false}
@@ -75,7 +75,7 @@ describe('LifecycleFilters', () => {
         onLifecycleDropdownSelect={jest.fn()}
         selectedChartSortBy="Retirement date"
         updateChartSortValue={jest.fn()}
-        downloadCSV={jest.fn()}
+        onExport={jest.fn()}
         selectedViewFilter="all"
         handleViewFilterChange={jest.fn()}
         noDataAvailable={false}
@@ -99,7 +99,7 @@ describe('LifecycleFilters', () => {
         onLifecycleDropdownSelect={jest.fn()}
         selectedChartSortBy="Retirement date"
         updateChartSortValue={jest.fn()}
-        downloadCSV={jest.fn()}
+        onExport={jest.fn()}
         selectedViewFilter="all"
         handleViewFilterChange={jest.fn()}
         noDataAvailable={false}
@@ -144,7 +144,7 @@ it('shows dynamic RHEL version options when in Systems view and Field=Version', 
       onLifecycleDropdownSelect={jest.fn()}
       selectedChartSortBy="Retirement date"
       updateChartSortValue={jest.fn()}
-      downloadCSV={jest.fn()}
+      onExport={jest.fn()}
       selectedViewFilter="installed-only"
       handleViewFilterChange={jest.fn()}
       noDataAvailable={false}
@@ -181,7 +181,7 @@ it('syncs selection with new dynamic options (intersection or fallback to all) a
       onLifecycleDropdownSelect={jest.fn()}
       selectedChartSortBy="Retirement date"
       updateChartSortValue={jest.fn()}
-      downloadCSV={jest.fn()}
+      onExport={jest.fn()}
       selectedViewFilter="installed-only"
       handleViewFilterChange={jest.fn()}
       noDataAvailable={false}
@@ -206,7 +206,7 @@ it('syncs selection with new dynamic options (intersection or fallback to all) a
       onLifecycleDropdownSelect={jest.fn()}
       selectedChartSortBy="Retirement date"
       updateChartSortValue={jest.fn()}
-      downloadCSV={jest.fn()}
+      onExport={jest.fn()}
       selectedViewFilter="installed-only"
       handleViewFilterChange={jest.fn()}
       noDataAvailable={false}
@@ -239,7 +239,7 @@ it('keeps both Name keyword and Version selection effective when switching Field
       onLifecycleDropdownSelect={jest.fn()}
       selectedChartSortBy="Retirement date"
       updateChartSortValue={jest.fn()}
-      downloadCSV={jest.fn()}
+      onExport={jest.fn()}
       selectedViewFilter="installed-only"
       handleViewFilterChange={jest.fn()}
       noDataAvailable={false}
@@ -299,7 +299,7 @@ describe('Status Filter Functionality', () => {
     onLifecycleDropdownSelect: jest.fn(),
     selectedChartSortBy: 'Retirement date',
     updateChartSortValue: jest.fn(),
-    downloadCSV: jest.fn(),
+    onExport: jest.fn(),
     selectedViewFilter: 'installed-only',
     handleViewFilterChange: jest.fn(),
     noDataAvailable: false,

--- a/src/Components/LifecycleFilters/LifecycleFilters.tsx
+++ b/src/Components/LifecycleFilters/LifecycleFilters.tsx
@@ -13,6 +13,7 @@ import {
   ToolbarGroup,
   ToolbarItem,
 } from '@patternfly/react-core';
+import { ExportFormat } from '../ExportDataButton/ExportDataButton';
 import { ErrorObject } from '../../types/ErrorObject';
 import LifecycleDropdown from '../FilterComponents/LifecycleDropdown';
 import {
@@ -34,7 +35,7 @@ interface LifecycleFiltersProps {
   onLifecycleDropdownSelect: (value: string) => void;
   selectedChartSortBy: string;
   updateChartSortValue: (name: string, order: string) => void;
-  downloadCSV: () => void;
+  onExport: (format: ExportFormat) => void;
   selectedViewFilter: string;
   handleViewFilterChange: (filter: string) => void;
   noDataAvailable: boolean;
@@ -105,7 +106,7 @@ export const LifecycleFilters: React.FunctionComponent<LifecycleFiltersProps> = 
   onLifecycleDropdownSelect,
   selectedChartSortBy,
   updateChartSortValue,
-  downloadCSV,
+  onExport,
   selectedViewFilter,
   handleViewFilterChange,
   noDataAvailable,
@@ -512,7 +513,7 @@ export const LifecycleFilters: React.FunctionComponent<LifecycleFiltersProps> = 
             onToggleClick={onToggleClick}
             onSelect={onSelect}
             setIsOpen={setIsOpen}
-            downloadCSV={downloadCSV}
+            onExport={onExport}
             disableInstalledOnly={disableInstalledOnly ?? false}
           />
         ) : (
@@ -549,7 +550,7 @@ export const LifecycleFilters: React.FunctionComponent<LifecycleFiltersProps> = 
             onToggleClick={onToggleClick}
             onSelect={onSelect}
             setIsOpen={setIsOpen}
-            downloadCSV={downloadCSV}
+            onExport={onExport}
             disableInstalledOnly={disableInstalledOnly ?? false}
           />
         )}

--- a/src/Components/LifecycleFilters/SystemsViewToolbar.test.tsx
+++ b/src/Components/LifecycleFilters/SystemsViewToolbar.test.tsx
@@ -43,7 +43,7 @@ describe('SystemsViewToolbar', () => {
     onToggleClick: jest.fn(),
     onSelect: jest.fn(),
     setIsOpen: jest.fn(),
-    downloadCSV: jest.fn(),
+    onExport: jest.fn(),
     disableInstalledOnly: false,
   };
 
@@ -268,19 +268,16 @@ describe('SystemsViewToolbar', () => {
     });
   });
 
-  describe('Download CSV Button', () => {
-    test('calls downloadCSV when download button is clicked', () => {
-      const downloadCSV = jest.fn();
-      render(<SystemsViewToolbar {...defaultProps} downloadCSV={downloadCSV} />);
+  describe('Export Button', () => {
+    test('renders successfully with onExport prop', () => {
+      render(<SystemsViewToolbar {...defaultProps} />);
 
-      // Component should render successfully with downloadCSV prop
       expect(screen.getByRole('button', { name: 'Installed and related' })).toBeInTheDocument();
     });
 
-    test('renders successfully with downloadCSV prop', () => {
+    test('renders all view filter buttons', () => {
       render(<SystemsViewToolbar {...defaultProps} />);
 
-      // Component should still render even when download is present
       expect(screen.getByRole('button', { name: 'All' })).toBeInTheDocument();
     });
   });

--- a/src/Components/LifecycleFilters/SystemsViewToolbar.tsx
+++ b/src/Components/LifecycleFilters/SystemsViewToolbar.tsx
@@ -22,7 +22,7 @@ import {
   Tooltip,
 } from '@patternfly/react-core';
 import { FilterIcon } from '@patternfly/react-icons';
-import ExportDataButton from '../ExportDataButton/ExportDataButton';
+import ExportDataButton, { ExportFormat } from '../ExportDataButton/ExportDataButton';
 
 const FIELD_OPTIONS = ['Name', 'Version', 'Status'] as const;
 const DROPDOWN_ITEMS = ['Retirement date', 'Name', 'Release version', 'Release date', 'Systems'];
@@ -63,7 +63,7 @@ interface SystemsViewToolbarProps {
     value: string | number | undefined
   ) => void;
   setIsOpen: (open: boolean) => void;
-  downloadCSV: () => void;
+  onExport: (format: ExportFormat) => void;
   disableInstalledOnly: boolean;
 }
 
@@ -100,7 +100,7 @@ export const SystemsViewToolbar: React.FunctionComponent<SystemsViewToolbarProps
   onToggleClick,
   onSelect,
   setIsOpen,
-  downloadCSV,
+  onExport,
   disableInstalledOnly,
 }) => {
   return (
@@ -208,7 +208,7 @@ export const SystemsViewToolbar: React.FunctionComponent<SystemsViewToolbarProps
               </Form>
             </ToolbarItem>
             <ToolbarItem>
-              <ExportDataButton className="drf-lifecycle__filter-download" onClick={downloadCSV} />
+              <ExportDataButton className="drf-lifecycle__filter-download" onExport={onExport} />
             </ToolbarItem>
           </ToolbarGroup>
         </ToolbarContent>

--- a/src/Components/UpcomingTable/UpcomingTable.test.tsx
+++ b/src/Components/UpcomingTable/UpcomingTable.test.tsx
@@ -30,8 +30,8 @@ jest.mock('./UpcomingTableFilters', () => {
     handleViewFilterChange,
     noDataAvailable,
     typeOptions,
-    downloadCSV,
-    canDownloadCSV,
+    onExport,
+    canExport,
   }: any) {
     return (
       <div data-testid="upcoming-table-filters">
@@ -66,8 +66,8 @@ jest.mock('./UpcomingTableFilters', () => {
         <button data-testid="change-view-filter" onClick={() => handleViewFilterChange('all')}>
           Change View Filter
         </button>
-        <button data-testid="download-csv" onClick={downloadCSV} disabled={!canDownloadCSV}>
-          Download CSV
+        <button data-testid="export-csv" onClick={() => onExport?.('csv')} disabled={!canExport}>
+          Export CSV
         </button>
       </div>
     );
@@ -457,14 +457,14 @@ describe('UpcomingTable', () => {
         expect(screen.queryByTestId('table-row-PostgreSQL 15 Feature')).not.toBeInTheDocument();
       });
 
-      fireEvent.click(screen.getByTestId('download-csv'));
+      fireEvent.click(screen.getByTestId('export-csv'));
       expect(mockedGenerateCsv).toHaveBeenCalled();
       expect(mockedDownload).toHaveBeenCalled();
     });
 
-    test('disables CSV export when there are no rows to export', async () => {
+    test('disables export when there are no rows to export', async () => {
       render(<UpcomingTable {...defaultProps} data={[]} />);
-      expect(screen.getByTestId('download-csv')).toBeDisabled();
+      expect(screen.getByTestId('export-csv')).toBeDisabled();
     });
 
     test('updates when data prop changes', async () => {

--- a/src/Components/UpcomingTable/UpcomingTable.test.tsx
+++ b/src/Components/UpcomingTable/UpcomingTable.test.tsx
@@ -4,12 +4,9 @@ import '@testing-library/jest-dom';
 import UpcomingTable from './UpcomingTable';
 import { UpcomingChanges } from '../../types/UpcomingChanges';
 import { DEFAULT_FILTERS } from '../../utils/utils';
-import { download, generateCsv } from 'export-to-csv';
-
-jest.mock('export-to-csv', () => ({
-  mkConfig: jest.fn(() => ({})),
-  generateCsv: jest.fn(() => () => 'csv,data'),
-  download: jest.fn(() => () => {}),
+const mockExportData = jest.fn();
+jest.mock('../../utils/export', () => ({
+  exportData: (...args: any[]) => mockExportData(...args),
 }));
 
 // Mock the UpcomingTableFilters component
@@ -169,9 +166,6 @@ const defaultProps = {
 };
 
 describe('UpcomingTable', () => {
-  const mockedDownload = download as jest.Mock;
-  const mockedGenerateCsv = generateCsv as jest.Mock;
-
   beforeEach(() => {
     jest.clearAllMocks();
   });
@@ -458,8 +452,7 @@ describe('UpcomingTable', () => {
       });
 
       fireEvent.click(screen.getByTestId('export-csv'));
-      expect(mockedGenerateCsv).toHaveBeenCalled();
-      expect(mockedDownload).toHaveBeenCalled();
+      expect(mockExportData).toHaveBeenCalledWith('csv', expect.any(Array));
     });
 
     test('disables export when there are no rows to export', async () => {

--- a/src/Components/UpcomingTable/UpcomingTable.tsx
+++ b/src/Components/UpcomingTable/UpcomingTable.tsx
@@ -19,6 +19,7 @@ import UpcomingTableFilters from './UpcomingTableFilters';
 import { Filter } from '../../types/Filter';
 import { DEFAULT_FILTERS, KNOWN_TYPES } from '../../utils/utils';
 import { download, generateCsv, mkConfig } from 'export-to-csv';
+import { ExportFormat } from '../ExportDataButton/ExportDataButton';
 
 interface UpcomingTableProps {
   data: UpcomingChanges[];
@@ -351,8 +352,8 @@ export const UpcomingTable: React.FunctionComponent<UpcomingTableProps> = ({
     setExpandedRows(newExpandedRows);
   };
 
-  const downloadCSV = () => {
-    const data = sortedFilteredData.map((item) => ({
+  const buildExportData = () =>
+    sortedFilteredData.map((item) => ({
       Name: item.name,
       Type: item.type,
       Release: item.release,
@@ -361,8 +362,47 @@ export const UpcomingTable: React.FunctionComponent<UpcomingTableProps> = ({
       'Affected systems': item.details?.potentiallyAffectedSystemsCount ?? '',
       'Tracking ticket': item.details?.trainingTicket ?? '',
     }));
-    const csv = generateCsv(csvConfig)(data);
-    download(csvConfig)(csv);
+
+  const downloadFile = (content: string, filename: string, mimeType: string) => {
+    const blob = new Blob([content], { type: mimeType });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = filename;
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const exportData = (format: ExportFormat) => {
+    const data = buildExportData();
+
+    switch (format) {
+      case 'csv': {
+        const csv = generateCsv(csvConfig)(data);
+        download(csvConfig)(csv);
+        break;
+      }
+      case 'json': {
+        downloadFile(JSON.stringify(data, null, 2), 'export.json', 'application/json');
+        break;
+      }
+      case 'xml': {
+        const xmlRows = data
+          .map((row) => {
+            const fields = Object.entries(row)
+              .map(([key, value]) => {
+                const tag = key.replace(/\s+/g, '_');
+                return `      <${tag}>${value}</${tag}>`;
+              })
+              .join('\n');
+            return `    <row>\n${fields}\n    </row>`;
+          })
+          .join('\n');
+        const xml = `<?xml version="1.0" encoding="UTF-8"?>\n<data>\n${xmlRows}\n</data>`;
+        downloadFile(xml, 'export.xml', 'application/xml');
+        break;
+      }
+    }
   };
 
   return (
@@ -393,8 +433,8 @@ export const UpcomingTable: React.FunctionComponent<UpcomingTableProps> = ({
         selectedViewFilter={selectedViewFilter}
         handleViewFilterChange={handleViewFilterChange}
         noDataAvailable={noDataAvailable}
-        downloadCSV={downloadCSV}
-        canDownloadCSV={sortedFilteredData.length > 0}
+        onExport={exportData}
+        canExport={sortedFilteredData.length > 0}
       />
       <Table
         aria-label="Upcoming changes, deprecations, and additions to your system"

--- a/src/Components/UpcomingTable/UpcomingTable.tsx
+++ b/src/Components/UpcomingTable/UpcomingTable.tsx
@@ -18,8 +18,7 @@ import { UpcomingChanges } from '../../types/UpcomingChanges';
 import UpcomingTableFilters from './UpcomingTableFilters';
 import { Filter } from '../../types/Filter';
 import { DEFAULT_FILTERS, KNOWN_TYPES } from '../../utils/utils';
-import { download, generateCsv, mkConfig } from 'export-to-csv';
-import { ExportFormat } from '../ExportDataButton/ExportDataButton';
+import { exportData as exportToFile } from '../../utils/export';
 
 interface UpcomingTableProps {
   data: UpcomingChanges[];
@@ -79,8 +78,6 @@ export const UpcomingTable: React.FunctionComponent<UpcomingTableProps> = ({
   const [activeSortDirection, setActiveSortDirection] = React.useState<SortByDirection>();
   const [sortedFilteredData, setSortedFilteredData] = React.useState<UpcomingChanges[]>(data);
   const [expandedRows, setExpandedRows] = React.useState<Set<UpcomingChanges>>(new Set([]));
-  const csvConfig = mkConfig({ useKeysAsHeaders: true });
-
   useEffect(() => {
     if (initialTypeFilters.size === 0) {
       setTypeSelections(new Set());
@@ -363,46 +360,9 @@ export const UpcomingTable: React.FunctionComponent<UpcomingTableProps> = ({
       'Tracking ticket': item.details?.trainingTicket ?? '',
     }));
 
-  const downloadFile = (content: string, filename: string, mimeType: string) => {
-    const blob = new Blob([content], { type: mimeType });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = filename;
-    a.click();
-    URL.revokeObjectURL(url);
-  };
-
-  const exportData = (format: ExportFormat) => {
+  const handleExport = (format: 'csv' | 'json' | 'xml') => {
     const data = buildExportData();
-
-    switch (format) {
-      case 'csv': {
-        const csv = generateCsv(csvConfig)(data);
-        download(csvConfig)(csv);
-        break;
-      }
-      case 'json': {
-        downloadFile(JSON.stringify(data, null, 2), 'export.json', 'application/json');
-        break;
-      }
-      case 'xml': {
-        const xmlRows = data
-          .map((row) => {
-            const fields = Object.entries(row)
-              .map(([key, value]) => {
-                const tag = key.replace(/\s+/g, '_');
-                return `      <${tag}>${value}</${tag}>`;
-              })
-              .join('\n');
-            return `    <row>\n${fields}\n    </row>`;
-          })
-          .join('\n');
-        const xml = `<?xml version="1.0" encoding="UTF-8"?>\n<data>\n${xmlRows}\n</data>`;
-        downloadFile(xml, 'export.xml', 'application/xml');
-        break;
-      }
-    }
+    exportToFile(format, data);
   };
 
   return (
@@ -433,7 +393,7 @@ export const UpcomingTable: React.FunctionComponent<UpcomingTableProps> = ({
         selectedViewFilter={selectedViewFilter}
         handleViewFilterChange={handleViewFilterChange}
         noDataAvailable={noDataAvailable}
-        onExport={exportData}
+        onExport={handleExport}
         canExport={sortedFilteredData.length > 0}
       />
       <Table

--- a/src/Components/UpcomingTable/UpcomingTableFilters.test.tsx
+++ b/src/Components/UpcomingTable/UpcomingTableFilters.test.tsx
@@ -15,7 +15,7 @@ const mockSetAddedToRoadmapSelection = jest.fn();
 const mockResetTypeFilter = jest.fn();
 const mockSetFiltersForURL = jest.fn();
 const mockHandleViewFilterChange = jest.fn();
-const mockDownloadCSV = jest.fn();
+const mockOnExport = jest.fn();
 
 const defaultProps = {
   itemCount: 50,
@@ -43,8 +43,8 @@ const defaultProps = {
   selectedViewFilter: 'relevant',
   handleViewFilterChange: mockHandleViewFilterChange,
   noDataAvailable: false,
-  downloadCSV: mockDownloadCSV,
-  canDownloadCSV: true,
+  onExport: mockOnExport,
+  canExport: true,
 };
 
 describe('UpcomingTableFilters', () => {

--- a/src/Components/UpcomingTable/UpcomingTableFilters.tsx
+++ b/src/Components/UpcomingTable/UpcomingTableFilters.tsx
@@ -23,7 +23,7 @@ import {
 import FilterIcon from '@patternfly/react-icons/dist/esm/icons/filter-icon';
 import './upcoming-table.scss';
 import { Filter } from '../../types/Filter';
-import ExportDataButton from '../ExportDataButton/ExportDataButton';
+import ExportDataButton, { ExportFormat } from '../ExportDataButton/ExportDataButton';
 
 interface UpcomingTableFiltersProps {
   resetFilters: () => void;
@@ -69,8 +69,8 @@ interface UpcomingTableFiltersProps {
   selectedViewFilter: string;
   handleViewFilterChange: (filter: string) => void;
   noDataAvailable?: boolean; // Add noDataAvailable prop with optional flag
-  downloadCSV: () => void;
-  canDownloadCSV: boolean;
+  onExport: (format: ExportFormat) => void;
+  canExport: boolean;
 }
 
 export const UpcomingTableFilters: React.FunctionComponent<UpcomingTableFiltersProps> = ({
@@ -99,8 +99,8 @@ export const UpcomingTableFilters: React.FunctionComponent<UpcomingTableFiltersP
   selectedViewFilter,
   handleViewFilterChange,
   noDataAvailable = false, // Default to false if not provided
-  downloadCSV,
-  canDownloadCSV,
+  onExport,
+  canExport,
 }) => {
   const [isReleaseMenuOpen, setIsReleaseMenuOpen] = useState<boolean>(false);
   const [isDateMenuOpen, setIsDateMenuOpen] = useState<boolean>(false);
@@ -557,8 +557,8 @@ export const UpcomingTableFilters: React.FunctionComponent<UpcomingTableFiltersP
             <ToolbarItem>
               <ExportDataButton
                 className="drf-upcoming__filter-download"
-                onClick={downloadCSV}
-                isDisabled={!canDownloadCSV}
+                onExport={onExport}
+                isDisabled={!canExport}
                 disabledTooltipContent="No data to export"
               />
             </ToolbarItem>

--- a/src/utils/export.test.ts
+++ b/src/utils/export.test.ts
@@ -1,0 +1,116 @@
+import { downloadFile, exportData, toXml } from './export';
+
+URL.createObjectURL = jest.fn(() => 'blob:mock-url');
+URL.revokeObjectURL = jest.fn();
+
+jest.mock('export-to-csv', () => ({
+  mkConfig: jest.fn(() => ({})),
+  generateCsv: jest.fn(() => () => 'csv,data'),
+  download: jest.fn(() => jest.fn()),
+}));
+
+describe('toXml', () => {
+  it('escapes special XML characters in values', () => {
+    const data = [{ name: 'host<2>', description: 'A & B "test" \'value\'' }];
+    const xml = toXml(data);
+
+    expect(xml).toContain('&lt;2&gt;');
+    expect(xml).toContain('A &amp; B &quot;test&quot; &apos;value&apos;');
+    expect(xml).not.toContain('<2>');
+  });
+
+  it('sanitizes tag names derived from keys', () => {
+    const data = [{ 'Affected systems': 5, '1bad': 'val' }];
+    const xml = toXml(data);
+
+    expect(xml).toContain('<Affected_systems>');
+    expect(xml).toContain('<_1bad>');
+    expect(xml).not.toContain('<Affected systems>');
+  });
+
+  it('produces well-formed XML for normal data', () => {
+    const data = [
+      { release: 'RHEL', version: '9.3' },
+      { release: 'RHEL', version: '8.9' },
+    ];
+    const xml = toXml(data);
+
+    expect(xml).toMatch(/^<\?xml version="1.0" encoding="UTF-8"\?>/);
+    expect(xml).toContain('<data>');
+    expect(xml).toContain('</data>');
+    expect((xml.match(/<row>/g) || []).length).toBe(2);
+  });
+
+  it('returns empty data element for empty array', () => {
+    const xml = toXml([]);
+    expect(xml).toBe('<?xml version="1.0" encoding="UTF-8"?>\n<data>\n\n</data>');
+  });
+});
+
+describe('downloadFile', () => {
+  let clickSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    clickSpy = jest.fn();
+    jest.spyOn(document, 'createElement').mockReturnValue({
+      href: '',
+      download: '',
+      click: clickSpy,
+    } as any);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('creates a blob URL and triggers a download', () => {
+    downloadFile('content', 'test.json', 'application/json');
+
+    expect(URL.createObjectURL).toHaveBeenCalledWith(expect.any(Blob));
+    expect(clickSpy).toHaveBeenCalled();
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:mock-url');
+  });
+});
+
+describe('exportData', () => {
+  const { generateCsv, download } = jest.requireMock('export-to-csv');
+  let clickSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    clickSpy = jest.fn();
+    jest.spyOn(document, 'createElement').mockReturnValue({
+      href: '',
+      download: '',
+      click: clickSpy,
+    } as any);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  const sampleData = [{ name: 'test', value: 1 }];
+
+  it('exports CSV using export-to-csv library', () => {
+    exportData('csv', sampleData);
+
+    expect(generateCsv).toHaveBeenCalled();
+    expect(download).toHaveBeenCalled();
+  });
+
+  it('exports JSON via downloadFile', () => {
+    exportData('json', sampleData);
+
+    expect(URL.createObjectURL).toHaveBeenCalled();
+    expect(clickSpy).toHaveBeenCalled();
+  });
+
+  it('exports XML with escaped values via downloadFile', () => {
+    exportData('xml', [{ host: 'a<b' }]);
+
+    expect(URL.createObjectURL).toHaveBeenCalled();
+    expect(clickSpy).toHaveBeenCalled();
+  });
+});

--- a/src/utils/export.ts
+++ b/src/utils/export.ts
@@ -1,0 +1,63 @@
+import { download, generateCsv, mkConfig } from 'export-to-csv';
+import { ExportFormat } from '../Components/ExportDataButton/ExportDataButton';
+
+type ExportRow = { [key: string]: string | number };
+
+const escapeXml = (val: string | number): string =>
+  String(val)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+
+const sanitizeTagName = (key: string): string =>
+  key
+    .replace(/\s+/g, '_')
+    .replace(/[^a-zA-Z0-9_.-]/g, '_')
+    .replace(/^(\d)/, '_$1');
+
+export const downloadFile = (content: string, filename: string, mimeType: string): void => {
+  const blob = new Blob([content], { type: mimeType });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  a.click();
+  URL.revokeObjectURL(url);
+};
+
+export const toXml = (data: ExportRow[]): string => {
+  const xmlRows = data
+    .map((row) => {
+      const fields = Object.entries(row)
+        .map(([key, value]) => {
+          const tag = sanitizeTagName(key);
+          return `      <${tag}>${escapeXml(value)}</${tag}>`;
+        })
+        .join('\n');
+      return `    <row>\n${fields}\n    </row>`;
+    })
+    .join('\n');
+  return `<?xml version="1.0" encoding="UTF-8"?>\n<data>\n${xmlRows}\n</data>`;
+};
+
+const csvConfig = mkConfig({ useKeysAsHeaders: true });
+
+export const exportData = (format: ExportFormat, data: ExportRow[]): void => {
+  switch (format) {
+    case 'csv': {
+      const csv = generateCsv(csvConfig)(data);
+      download(csvConfig)(csv);
+      break;
+    }
+    case 'json': {
+      downloadFile(JSON.stringify(data, null, 2), 'export.json', 'application/json');
+      break;
+    }
+    case 'xml': {
+      downloadFile(toXml(data), 'export.xml', 'application/xml');
+      break;
+    }
+  }
+};

--- a/src/utils/utils.test.ts
+++ b/src/utils/utils.test.ts
@@ -1,5 +1,7 @@
 import { renderHook } from '@testing-library/react';
-import { useChartDataAttributes } from './utils';
+import { buildExportData, useChartDataAttributes } from './utils';
+import { Stream } from '../types/Stream';
+import { SystemLifecycleChanges } from '../types/SystemLifecycleChanges';
 
 // Mock DOM elements
 class MockElement {
@@ -188,5 +190,158 @@ describe('useChartDataAttributes', () => {
     });
 
     expect(mockChartContainer.querySelectorAll).toHaveBeenCalled();
+  });
+});
+
+const APP_STREAM_DROPDOWNS = ['rhel-9-appstreams', 'rhel-8-appstreams', 'rhel-10-appstreams'];
+
+describe('buildExportData', () => {
+  const streamWithHosts: Stream[] = [
+    {
+      name: 'nodejs',
+      display_name: 'Node.js 18',
+      os_major: 9,
+      os_minor: 0,
+      start_date: '2023-01-01',
+      end_date: '2025-01-01',
+      count: 2,
+      rolling: false,
+      related: false,
+      support_status: 'Supported',
+      os_lifecycle: 'Supported',
+      application_stream_name: 'Node.js 18',
+      systems_detail: [
+        { id: 'host-1', display_name: 'server-1' },
+        { id: 'host-2', display_name: 'server-2' },
+      ],
+    },
+  ];
+
+  const streamWithoutHosts: Stream[] = [
+    {
+      name: 'python',
+      display_name: 'Python 3.11',
+      os_major: 9,
+      os_minor: 1,
+      start_date: '2022-06-01',
+      end_date: '2024-06-01',
+      count: 0,
+      rolling: false,
+      related: false,
+      support_status: 'Retired',
+      os_lifecycle: 'Supported',
+      application_stream_name: 'Python 3.11',
+      systems_detail: [],
+    },
+  ];
+
+  const systemWithHosts: SystemLifecycleChanges[] = [
+    {
+      name: 'RHEL',
+      display_name: 'RHEL 9.3',
+      major: 9,
+      minor: 3,
+      start_date: '2023-01-01',
+      end_date: '2025-01-01',
+      count: 1,
+      lifecycle_type: 'standard',
+      related: false,
+      support_status: 'Supported',
+      systems_detail: [{ id: 'sys-1', display_name: 'rhel-host-1' }],
+    },
+  ];
+
+  const systemWithoutHosts: SystemLifecycleChanges[] = [
+    {
+      name: 'RHEL',
+      display_name: 'RHEL 8.9',
+      major: 8,
+      minor: 9,
+      start_date: '2022-01-01',
+      end_date: '2024-01-01',
+      count: 0,
+      lifecycle_type: 'standard',
+      related: true,
+      support_status: 'Retired',
+      systems_detail: [],
+    },
+  ];
+
+  it('builds app stream export rows with host details', () => {
+    const result = buildExportData(streamWithHosts, 'rhel-9-appstreams', APP_STREAM_DROPDOWNS);
+
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual(
+      expect.objectContaining({
+        appstream_module: 'Node.js 18',
+        hostname: 'server-1',
+        host_id: 'host-1',
+        release: 9,
+        rhel_version: '9.0',
+        system_index: '1 of 2',
+      })
+    );
+    expect(result[1]).toEqual(
+      expect.objectContaining({
+        hostname: 'server-2',
+        system_index: '2 of 2',
+      })
+    );
+  });
+
+  it('builds app stream export rows without host details', () => {
+    const result = buildExportData(streamWithoutHosts, 'rhel-8-appstreams', APP_STREAM_DROPDOWNS);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual(
+      expect.objectContaining({
+        appstream_module: 'Python 3.11',
+        release: 9,
+        rhel_version: '9.1',
+        lifecycle_status: 'Retired',
+      })
+    );
+    expect(result[0]).not.toHaveProperty('hostname');
+    expect(result[0]).not.toHaveProperty('host_id');
+  });
+
+  it('builds system export rows with host details', () => {
+    const result = buildExportData(systemWithHosts, 'rhel-systems', APP_STREAM_DROPDOWNS);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual(
+      expect.objectContaining({
+        hostname: 'rhel-host-1',
+        host_id: 'sys-1',
+        release: 'RHEL',
+        rhel_version: '9.3',
+        system_index: '1 of 1',
+      })
+    );
+    expect(result[0]).not.toHaveProperty('appstream_module');
+  });
+
+  it('builds system export rows without host details', () => {
+    const result = buildExportData(systemWithoutHosts, 'rhel-systems', APP_STREAM_DROPDOWNS);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual(
+      expect.objectContaining({
+        release: 'RHEL',
+        rhel_version: '8.9',
+        lifecycle_status: 'Retired',
+      })
+    );
+    expect(result[0]).not.toHaveProperty('hostname');
+  });
+
+  it('returns empty array for empty input', () => {
+    expect(buildExportData([], 'rhel-9-appstreams', APP_STREAM_DROPDOWNS)).toEqual([]);
+    expect(buildExportData([], 'rhel-systems', APP_STREAM_DROPDOWNS)).toEqual([]);
+  });
+
+  it('puts appstream_module as the first key in stream exports', () => {
+    const result = buildExportData(streamWithHosts, 'rhel-9-appstreams', APP_STREAM_DROPDOWNS);
+    expect(Object.keys(result[0])[0]).toBe('appstream_module');
   });
 });

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -116,6 +116,73 @@ export const getNewName = (name: string, major: number, minor: number, lifecycle
   return `${name} ${major}.${minor}${lifecycleText}`;
 };
 
+import { Stream } from '../types/Stream';
+import { SystemLifecycleChanges } from '../types/SystemLifecycleChanges';
+
+export const buildExportData = (
+  filteredTableData: Stream[] | SystemLifecycleChanges[],
+  lifecycleDropdownValue: string,
+  appStreamDropdownValues: string[]
+): { [key: string]: string | number }[] => {
+  const data: { [key: string]: string | number }[] = [];
+  if (appStreamDropdownValues.includes(lifecycleDropdownValue)) {
+    (filteredTableData as Stream[]).forEach((stream: Stream) => {
+      const hosts = stream.systems_detail ?? [];
+      if (hosts.length > 0) {
+        hosts.forEach((host, index) => {
+          data.push({
+            appstream_module: stream.display_name,
+            hostname: host.display_name,
+            host_id: host.id,
+            release: stream.os_major,
+            release_date: formatDate(stream.start_date),
+            retirement_date: formatDate(stream.end_date),
+            lifecycle_status: stream.support_status,
+            rhel_version: `${stream.os_major}.${stream.os_minor}`,
+            system_index: `${index + 1} of ${stream.count}`,
+          });
+        });
+      } else {
+        data.push({
+          appstream_module: stream.display_name,
+          release: stream.os_major,
+          release_date: formatDate(stream.start_date),
+          retirement_date: formatDate(stream.end_date),
+          lifecycle_status: stream.support_status,
+          rhel_version: `${stream.os_major}.${stream.os_minor}`,
+        });
+      }
+    });
+  } else {
+    (filteredTableData as SystemLifecycleChanges[]).forEach((item: SystemLifecycleChanges) => {
+      const hosts = item.systems_detail ?? [];
+      if (hosts.length > 0) {
+        hosts.forEach((host, index) => {
+          data.push({
+            hostname: host.display_name,
+            host_id: host.id,
+            release: item.name,
+            release_date: formatDate(item.start_date),
+            retirement_date: formatDate(item.end_date),
+            lifecycle_status: item.support_status,
+            rhel_version: `${item.major}.${item.minor}`,
+            system_index: `${index + 1} of ${item.count}`,
+          });
+        });
+      } else {
+        data.push({
+          release: item.name,
+          release_date: formatDate(item.start_date),
+          retirement_date: formatDate(item.end_date),
+          lifecycle_status: item.support_status,
+          rhel_version: `${item.major}.${item.minor}`,
+        });
+      }
+    });
+  }
+  return data;
+};
+
 export const getNewChartName = (name: string, major: number, minor: number, lifecycleType: string) => {
   const lifecycleText = getLifecycleType(lifecycleType);
   return `${name} ${lifecycleText}`;

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,6 +1,8 @@
 import * as React from 'react';
 import { To } from 'react-router-dom';
 import { Filter } from '../types/Filter';
+import { Stream } from '../types/Stream';
+import { SystemLifecycleChanges } from '../types/SystemLifecycleChanges';
 
 export const KNOWN_TYPES = ['Addition', 'Enhancement', 'Change', 'Deprecation'] as const;
 
@@ -115,9 +117,6 @@ export const getNewName = (name: string, major: number, minor: number, lifecycle
   const lifecycleText = getLifecycleType(lifecycleType);
   return `${name} ${major}.${minor}${lifecycleText}`;
 };
-
-import { Stream } from '../types/Stream';
-import { SystemLifecycleChanges } from '../types/SystemLifecycleChanges';
 
 export const buildExportData = (
   filteredTableData: Stream[] | SystemLifecycleChanges[],


### PR DESCRIPTION
### Description
Replace the single CSV export button with a dropdown supporting CSV, JSON, and XML exports. Flatten export data to per-host rows using systems_detail arrays, with a fallback to stream-level rows when host data is unavailable (e.g. the "all" view).

Prototype: https://www.figma.com/proto/GoE74qifcLsJ8PRKFpNyS8/RHEL---Lightspeed-notifications?node-id=1188-12308&viewport=401%2C-1181%2C0.16&t=yIKGhCwGqmQDixNb-1&scaling=min-zoom&content-scaling=fixed&starting-point-node-id=1188%3A12728&page-id=1%3A3

Jira link:
[RHINENG-27229](https://redhat.atlassian.net/browse/RHINENG-27229)


### Screenshots
<!-- Before and after proposed changes is ideal -->
<!-- Any key UI permutations should be captured -->
<!-- Draw attention to the area of UI that has changed -->
#### Before:


#### After:
<img width="1531" height="825" alt="image" src="https://github.com/user-attachments/assets/63fe7406-59e1-4e6c-a6b9-1b9a0a488ba2" />

XML
<img width="681" height="921" alt="image" src="https://github.com/user-attachments/assets/44dc077a-476d-4c52-9d62-10b55cdf04b0" />

JSON
<img width="744" height="911" alt="image" src="https://github.com/user-attachments/assets/a121cb2d-c040-4f84-99bc-281c4c1c26b2" />

CSV
<img width="1074" height="919" alt="image" src="https://github.com/user-attachments/assets/963fb34f-dc92-497d-ae53-d872fd833d3c" />

---

### Checklist ☑️
- [ ] PR only fixes one issue or story <!-- open new PR for others -->
- [ ] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [ ] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [ ] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [ ] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##


[RHINENG-27229]: https://redhat.atlassian.net/browse/RHINENG-27229?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ